### PR TITLE
fix: DNS zone RG creation, ACA hostname bind timing, and array CLI args

### DIFF
--- a/src/azure/azureContainerApp.ts
+++ b/src/azure/azureContainerApp.ts
@@ -535,6 +535,14 @@ export class AzureContainerAppRender extends AzureResourceRender {
             ],
         });
 
+        // ── 等待 DNS 传播 ─────────────────────────────────────────────────────
+        // Azure DNS 控制平面返回 "Succeeded" 后，权威 DNS 服务器之间的同步
+        // 仍需数秒到数十秒，必须等待传播完成后再执行 hostname bind 验证。
+        commands.push({
+            command: 'bash',
+            args: ['-c', 'sleep 30'],
+        });
+
         // ── 步骤 5：将自定义域名绑定到容器应用 ──────────────────────────────
         commands.push({
             command: 'az',

--- a/src/azure/azureDnsZone.ts
+++ b/src/azure/azureDnsZone.ts
@@ -87,8 +87,10 @@ export class AzureDnsZoneRender extends AzureResourceRender {
      * to AzureResourceGroupRender which requires region. Instead, we check the RG directly
      * and generate a create command using config.location.
      */
-    private async ensureResourceGroupCommandsForDnsZone(resource: AzureDnsZoneResource, context?: RenderContext): Promise<Command[]> {
-        if (context?.skipResourceGroup) return [];
+    private async ensureResourceGroupCommandsForDnsZone(resource: AzureDnsZoneResource, _context?: RenderContext): Promise<Command[]> {
+        // DNS zones are global resources — their RG is never pre-created in the deployer's
+        // Level 0 pass (which only handles regional resources). We must always check/create
+        // the RG here regardless of skipResourceGroup.
 
         const resourceGroupName = this.getResourceGroupName(resource);
 

--- a/src/azure/render.ts
+++ b/src/azure/render.ts
@@ -1,5 +1,5 @@
 
-import { Command, Render, Region, Resource, RenderContext, REGION_SHORT_NAME_MAP, RING_SHORT_NAME_MAP } from "../common/resource";
+import { Command, Render, Resource, RenderContext, REGION_SHORT_NAME_MAP, RING_SHORT_NAME_MAP } from "../common/resource";
 import { resolveConfig } from "../common/paramResolver.js";
 
 
@@ -115,7 +115,9 @@ export abstract class AzureResourceRender implements Render {
             const value = config[configKey];
             if (Array.isArray(value) && value.length > 0) {
                 args.push(cliFlag);
-                args.push(value.join(' '));
+                for (const item of value) {
+                    args.push(String(item));
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- **`azureDnsZone.ts`**: Always create/check the Resource Group for DNS zones regardless of the `skipResourceGroup` flag. DNS zones are global resources and are never pre-created in the Level 0 regional pass.
- **`azureContainerApp.ts`**: Add a 30-second sleep before the custom hostname bind step to allow Azure DNS propagation to complete after the control plane reports "Succeeded".
- **`render.ts`**: Fix array-type CLI argument serialization — push each item individually instead of joining them into a single space-separated string argument.

## Test plan

- [x] Verify DNS Zone Resource Group is correctly created during deployment
- [x] Verify Container App custom domain binding works after DNS propagation wait
- [x] Verify array-type CLI flags (e.g. `--args`) generate multiple distinct arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)