### PR TITLE
feat: health probes, EasyAuth, custom domain binding, NS delegation, AD App client ID fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,23 @@ Merlin uses registries (global Maps) for runtime lookup:
 
 All registrations happen in `src/init.ts` and are imported by generated code via `import 'merlin/init.js'`.
 
+### ProprietyGetter Implementations (`src/azure/proprietyGetter.ts`)
+
+ProprietyGetters produce the Azure CLI command that resolves a resource export at deploy time. Available getters:
+
+| Getter name | Returns |
+|-------------|---------|
+| `AzureResourceManagedIdentity` | Object ID of the resource's managed identity |
+| `AzureResourceName` | The Azure resource name (via `getResourceName()`) |
+| `AzureContainerRegistryServer` | ACR login server URL (e.g. `myacr.azurecr.io`) |
+| `AzureContainerAppFqdn` | Container App default ingress FQDN |
+| `AzureLogAnalyticsWorkspaceCustomerId` | LAW customer ID |
+| `AzureLogAnalyticsWorkspaceSharedKey` | LAW primary shared key |
+| `AzureADAppClientId` | AD App `appId` (client ID), looked up by display name |
+| `AzureDnsZoneName` | Full DNS zone name (e.g. `chuang.staging.thebrainly.dev`) |
+
+**Important — `AzureADAppClientId`**: The AD App's `displayName` config field may contain `${ }` parameter expressions (e.g. `merlintest-alluneed-${ this.ring }`). These are stored as `ParamValue` objects at registration time and must be resolved before use. The getter calls `resolveConfig()` first, then `render.getDisplayName(resolved)` to get the correct string. `getDisplayName()` uses the **full** ring name (`staging`, not `stg`) — do not use `getResourceName()` which uses the short ring form.
+
 ### Dependency Resolution
 
 Dependencies are declared in YAML (`dependencies[].resource`). Each dependency can specify:
@@ -172,6 +189,46 @@ Azure resources follow a consistent naming pattern (see `src/azure/render.ts`):
   - Some resources don't support hyphens (set `supportConnectorInResourceName: false`)
 
 Regions are abbreviated using `REGION_SHORT_NAME_MAP`: `eastasia` → `eas`, `koreacentral` → `krc`, etc.
+
+## Azure-Specific Features
+
+### DNS Zone NS Delegation (`src/azure/azureDnsZone.ts`)
+
+When a DNS Zone resource has `parentName` set in its config, `renderCreate()` automatically appends 10 additional commands after the zone creation command (11 total):
+
+1. Capture NS server 1–4 from the new zone (`az network dns zone show --query nameServers[0..3]`)
+2. Capture the parent zone's resource group (`az network dns zone list`)
+3. Create the NS record-set in the parent zone (`az network dns record-set ns create --ttl 3600`)
+4. Add all 4 NS records to the record-set (`az network dns record-set ns add-record` × 4)
+
+This wires up the child zone's delegation in the parent zone automatically on first create. On `renderUpdate()` NS delegation is **not** re-emitted (it is a one-time setup).
+
+The relative label for the NS record-set is the `dnsName` field (e.g. `chuang.staging`); the target zone is `parentName` (e.g. `thebrainly.dev`).
+
+### Container App DNS Binding (`src/azure/azureContainerApp.ts`)
+
+When `bindDnsZone: { dnsZone, subDomain }` is set in the ACA config, `renderBindDnsZone()` appends these steps after the container app create/update command:
+
+| Step | Command | Notes |
+|------|---------|-------|
+| 0a | `az network dns zone list` | Capture DNS Zone RG into `$MERLIN_..._DNS_ZONE_RG` |
+| 0b | `az containerapp show --query managedEnvironmentId` | Capture env ARM ID |
+| 0c | `bash -c "echo $VAR \| sed 's\|.*/\|\|'"` | Extract env name from ARM ID |
+| 1 | `bash -c "az containerapp hostname add ... \|\| true"` | Register hostname (idempotent) |
+| 2 | `az containerapp show --query ingress.fqdn` | Capture default FQDN |
+| 3 | `az network dns record-set cname set-record` | Create CNAME pointing to default FQDN |
+| 4 | `az containerapp show --query customDomainVerificationId` | Capture verification ID |
+| 5 | `az network dns record-set txt add-record` (name: `asuid.<subDomain>`) | TXT verification record |
+| — | `bash -c "sleep 30"` | Wait for DNS propagation |
+| 6 | `bash -c "az containerapp hostname bind --validation-method CNAME \|\| true"` | Bind + request managed cert (idempotent) |
+
+**Azure ordering requirement**: `hostname add` (Step 1) must run before `hostname bind` (Step 6). Azure rejects cert requests for hostnames not yet registered on the container app.
+
+**Idempotency**: Steps 1 and 6 use `bash -c '... || true'` to swallow the "already exists" error on re-runs.
+
+### Global Resources (`isGlobalResource`)
+
+Some Azure resources are tenant-scoped and have no region (e.g. `AzureADApp`). Setting `isGlobalResource = true` on the Render implementation allows region-aware resources to resolve them by ring only, ignoring region. The registry lookup falls back to ring-only match when an exact ring+region match is not found for a global resource.
 
 ## Adding New Resource Types
 
@@ -254,3 +311,8 @@ When `ring` and `region` are arrays, Merlin generates a cartesian product (e.g.,
 - **Deep merge semantics** - objects merge recursively, arrays/primitives replace
 - **Resource keys are unique** - `name:ring:region` must be unique across all resources
 - **Test isolation** - use `clearRegistry()` in test teardown to reset global state
+- **`resolveConfig()` in ProprietyGetters** - config fields may be unresolved `ParamValue` objects at getter call time; always call `resolveConfig()` before reading config values that might contain `${ }` expressions
+- **`getDisplayName()` vs `getResourceName()`** - for AD Apps (and any resource with a configurable display name), use `getDisplayName()` which returns the full ring name; `getResourceName()` uses the short ring form (`stg`, `tst`) suitable for Azure resource names but not for AD App lookups
+- **`bash -c '... || true'` pattern** - use this for idempotent Azure CLI steps that fail with "already exists" on re-runs (e.g. `hostname add`, `hostname bind`)
+- **NS delegation is create-only** - `renderNsDelegation()` is called from `renderCreate()` only; if a zone was created outside Merlin, manually run the NS delegation commands against the parent zone
+- **After `pnpm build` in merlin root, also rebuild `.merlin/`** - the `.merlin/` project bundles merlin's `dist/init.js` at build time; run `merlin compile` (or `pnpm build` inside `.merlin/`) to pick up merlin source changes

--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
 # Merlin
 
-CLI tool for Infrastructure as Code deployment and management
+Declarative Infrastructure as Code (IaC) tool for Azure. Define resources in YAML, compile to TypeScript, deploy via Azure CLI.
 
 ## Overview
 
-Merlin is a declarative infrastructure deployment tool designed to automate the creation and management of cloud resources, with a focus on Azure services. It allows you to define your infrastructure in YAML configuration files and automatically handles resource creation, dependency resolution, permission management, and environment configuration.
+Merlin follows a **compile-time + runtime** architecture:
 
-## Features
-
-- **Declarative Configuration**: Define your infrastructure using simple YAML files
-- **Automatic Dependency Resolution**: Topological sorting ensures resources are created in the correct order
-- **Multi-environment Support**: Manage different rings (test, staging, production) and regions
-- **Permission Management**: Automatic setup of authentication and authorization between resources
-- **Dry Run Mode**: Preview changes before applying them
-- **Extensible Architecture**: Easy to add support for new resource types
+1. **Compile** — YAML resource definitions → TypeScript code (output to `.merlin/`)
+2. **Deploy** — TypeScript is executed to render Azure CLI commands, which are then run (or previewed)
 
 ## Installation
 
@@ -25,114 +19,164 @@ pnpm link:global
 
 ## Usage
 
-### Deploy Infrastructure
-
 ```bash
-# Deploy all resources
-merlin deploy
+# Compile YAML resources to TypeScript
+merlin compile [path]
 
-# Dry run mode (preview changes without applying)
-merlin deploy --dry-run
+# Preview deployment commands (dry-run, default)
+merlin deploy --input [path]
 
-# Deploy to specific ring and region
-merlin deploy --ring production --region eastus
+# Execute the deployment
+merlin deploy --input [path] --execute
+
+# Deploy to a specific ring and region
+merlin deploy --input [path] --ring staging --region eastasia
+
+# Write commands to a shell script
+merlin deploy --input [path] --output-file commands.sh
+
+# Validate resource configuration only
+merlin compile [path] --validate-only
 ```
 
-### Validate Configuration
+## Resource Configuration
 
-```bash
-# Validate all configuration files
-merlin validate
-
-# Validate specific file
-merlin validate resources/worker.yml
-```
-
-## Configuration
-
-Resources are defined in YAML files under the `resources/` directory. See the [design document](docs/design.md) for detailed configuration schema.
-
-### Example Resource Configuration
+Resources are defined in YAML files. Example:
 
 ```yaml
-name: worker
+name: myapp
 type: AzureContainerApp
-parent: cae
+project: myproject
 ring:
-  - test
+  - staging
   - production
 region:
-  - eastus
-  - westus
-authProvider: microsoftIdentityProviderAuth
+  - eastasia
+  - koreacentral
+
+authProvider:
+  name: AzureEntraID
 
 dependencies:
-  - resource: acr
+  - resource: AzureContainerRegistry.myacr
     isHardDependency: true
-  - resource: postgresql
-  - resource: redis
+  - resource: AzureDnsZone.mydns
 
 defaultConfig:
-  cpu: 2
-  memory: 4Gi
-  env:
-    - name: REDIS_URL
-      value: ${ redis.connectionString }
-    - name: DATABASE_URL
-      value: ${ postgresql.connectionString }
+  image: ${ AzureContainerRegistry.myacr.server }/myapp:latest
+  cpu: 0.5
+  memory: 1Gi
+  bindDnsZone:
+    dnsZone: ${ AzureDnsZone.mydns.domainName }
+    subDomain: myapp.${ this.region }.${ this.ring }
 
 specificConfig:
   - ring: production
-    region: eastus
-    cpu: 4
-    memory: 8Gi
+    cpu: 2
+    memory: 4Gi
 
 exports:
-  - url: getResourceUrl
-  - identity: getResourceIdentity
+  fqdn: AzureContainerAppFqdn
 ```
 
-## Development
+### Key YAML Fields
 
-### Project Structure
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | ✓ | Resource identifier (unique per ring+region) |
+| `type` | ✓ | Resource type (e.g. `AzureContainerApp`, `AzureDnsZone`) |
+| `project` | | Project prefix; omit for shared resources |
+| `ring` | ✓ | `test`, `staging`, `production` — or an array |
+| `region` | | `eastasia`, `koreacentral`, etc. — or an array |
+| `authProvider` | ✓ | Auth provider name or `{name, ...args}` |
+| `dependencies` | ✓ | Array of `{resource, isHardDependency?, authProvider?}` |
+| `defaultConfig` | ✓ | Base configuration (resource-specific schema) |
+| `specificConfig` | ✓ | Array of per-ring/region config overrides |
+| `exports` | ✓ | Map of export name → ProprietyGetter name |
+
+When `ring` and `region` are arrays, Merlin generates a cartesian product (e.g. 2 rings × 2 regions = 4 resources).
+
+### Parameter Expressions
+
+Config values can reference other resources using `${ }` expressions:
+
+```yaml
+# Reference another resource's export
+image: ${ AzureContainerRegistry.myacr.server }/myapp:latest
+
+# Reference the current resource's ring or region
+subDomain: myapp.${ this.region }.${ this.ring }
+```
+
+At deploy time these are resolved to shell variable captures (`$MERLIN_ACR_MYACR_STG_EAS_SERVER`), so dry-run works even when resources don't exist yet.
+
+## Supported Resource Types
+
+| Type | Description |
+|------|-------------|
+| `AzureContainerApp` | Container Apps with optional DNS binding and EasyAuth |
+| `AzureContainerAppEnvironment` | Container App Environments |
+| `AzureContainerRegistry` | Container Registries |
+| `AzureLogAnalyticsWorkspace` | Log Analytics Workspaces |
+| `AzureDnsZone` | DNS Zones (with optional NS delegation to parent zone) |
+| `AzureADApp` | Azure AD / Entra ID App Registrations |
+| `AzureBlobStorage` | Blob Storage Accounts |
+| `AzureResourceGroup` | Resource Groups (auto-created, deduplicated) |
+
+## Project Structure
 
 ```
 merlin/
 ├── src/
-│   ├── merlin.ts           # CLI entry point
-│   ├── types/              # Type definitions
-│   ├── render/             # Resource renderers
-│   ├── actions/            # Authentication and permission actions
-│   └── utils/              # Utility functions
-├── docs/                   # Documentation
-└── resources/              # Resource configuration files
+│   ├── merlin.ts                  # CLI entry point (Commander.js)
+│   ├── deployer.ts                # Deployment orchestration (DAG executor)
+│   ├── init.ts                    # Registers all providers/renders/getters
+│   ├── runtime.ts                 # Public API for generated code
+│   ├── common/
+│   │   ├── compiler.ts            # Compiler pipeline orchestration
+│   │   ├── registry.ts            # Resource registry (name:ring:region → Resource)
+│   │   ├── resource.ts            # Core types, render/auth registries
+│   │   └── paramResolver.ts       # Runtime ${ } expression resolver
+│   ├── compiler/
+│   │   ├── parser.ts              # YAML → raw resource objects
+│   │   ├── validator.ts           # Zod schema + semantic validation
+│   │   ├── transformer.ts         # Ring×region expansion, config merging
+│   │   ├── generator.ts           # TypeScript code generation
+│   │   ├── initializer.ts         # .merlin/ pnpm project setup
+│   │   └── schemas.ts             # Zod schemas for YAML validation
+│   └── azure/
+│       ├── render.ts              # AzureResourceRender base class + naming
+│       ├── azureContainerApp.ts   # ACA render (create/update/DNS bind/EasyAuth)
+│       ├── azureContainerAppEnv.ts
+│       ├── azureContainerRegistry.ts
+│       ├── azureDnsZone.ts        # DNS Zone render (+ NS delegation)
+│       ├── azureADApp.ts          # AD App render (global resource)
+│       ├── azureBlobStorage.ts
+│       ├── azureLogAnalyticsWorkspace.ts
+│       ├── resourceGroup.ts
+│       ├── proprietyGetter.ts     # ProprietyGetter implementations
+│       └── authProvider.ts        # AuthProvider implementations
+├── resources/                     # YAML resource definitions (user input)
+└── .merlin/                       # Generated TypeScript project (git-ignored)
 ```
 
-### Available Scripts
+## Development
 
-- `pnpm dev` - Run the CLI in development mode
-- `pnpm build` - Build the project
-- `pnpm test` - Run tests
-- `pnpm test:watch` - Run tests in watch mode
-- `pnpm lint` - Lint code
-- `pnpm lint:fix` - Lint and fix code
+```bash
+pnpm test          # Run all tests
+pnpm test:watch    # Watch mode
+pnpm lint          # Lint
+pnpm lint:fix      # Lint and auto-fix
+```
 
 ### Adding New Resource Types
 
-1. Define the resource schema in `src/types/`
-2. Create a renderer in `src/render/`
-3. Register the resource type in the main execution flow
-4. Add tests for the new resource type
+1. Create `src/azure/azureNewResource.ts` — export type constant + `AzureNewResourceRender extends AzureResourceRender`
+2. Register in `src/init.ts`: `registerRender(AZURE_NEW_RESOURCE_TYPE, new AzureNewResourceRender())`
+3. Add Zod schema entry in `src/compiler/schemas.ts` if needed
+4. Write tests in `src/azure/test/azureNewResource.test.ts`
 
-## Architecture
-
-Merlin follows a declarative approach where you specify the desired state of your infrastructure, and the tool handles the execution details:
-
-1. **Load Resources**: Parse YAML configuration files
-2. **Validate Dependencies**: Ensure all dependencies exist and are valid
-3. **Topological Sort**: Determine the correct order for resource creation
-4. **Render Commands**: Convert resource definitions to executable commands
-5. **Execute**: Run commands or show dry-run preview
+See `CLAUDE.md` for full architecture details and conventions.
 
 ## License
 

--- a/alluneed-resource/alluneedaca.yml
+++ b/alluneed-resource/alluneedaca.yml
@@ -18,6 +18,8 @@ dependencies:
     isHardDependency: true
   - resource: AzureDnsZone.chuangdns
     isHardDependency: false
+  - resource: AzureADApp.alluneed
+    isHardDependency: true
 
 defaultConfig:
   # ── Container / Image ─────────────────────────────────────────────
@@ -36,10 +38,38 @@ defaultConfig:
     - DEBUG_MODE=False
     - LOG_LEVEL=INFO
 
+  # ── Health probes ──────────────────────────────────────────────────────────
+  probes:
+    - type: Liveness
+      httpGet:
+        path: /
+        port: 8000
+        scheme: HTTP
+      periodSeconds: 60
+      timeoutSeconds: 30
+      failureThreshold: 30
+    - type: Readiness
+      httpGet:
+        path: /
+        port: 8000
+        scheme: HTTP
+      periodSeconds: 10
+      timeoutSeconds: 30
+      failureThreshold: 30
+    - type: Startup
+      httpGet:
+        path: /
+        port: 8000
+        scheme: HTTP
+      initialDelaySeconds: 1
+      periodSeconds: 10
+      timeoutSeconds: 30
+      failureThreshold: 30
+
 
   # ── Ingress (CREATE ONLY) ──────────────────────────────────────────
   ingress: external
-  targetPort: 8080
+  targetPort: 8000
   transport: auto
   allowInsecure: false
 
@@ -62,6 +92,17 @@ defaultConfig:
 
   # ── Misc ──────────────────────────────────────────────────────────
   noWait: false
+
+  # ── EasyAuth (Built-in Authentication) ────────────────────────────
+  # Merlin will automatically:
+  #   1. Generate a client secret on the AD App (az ad app credential reset --append)
+  #   2. Store the secret in an ACA secret (microsoft-provider-authentication-secret)
+  #   3. Update the AD App's webRedirectUris with the ACA callback URL
+  #   4. Enable EasyAuth and configure the Microsoft identity provider
+  auth:
+    clientId: ${ AzureADApp.alluneed.clientId }
+    issuer: https://sts.windows.net/2c10b0b9-d9c1-4c81-85ee-6a2297ed77f4/v2.0
+    unauthenticatedClientAction: RedirectToLoginPage
 
   bindDnsZone:
       dnsZone: ${ AzureDnsZone.chuangdns.domainName }

--- a/alluneed-resource/alluneedadapp.yml
+++ b/alluneed-resource/alluneedadapp.yml
@@ -1,0 +1,26 @@
+name: alluneed
+type: AzureADApp
+project: merlintest
+ring:
+  - staging
+  - test
+
+authProvider:
+  name: AzureEntraID
+
+dependencies: []
+
+defaultConfig:
+  # Display name for the Azure AD App (used as lookup key)
+  displayName: merlintest-alluneed-${ this.ring }
+
+  # Sign-in audience: single tenant
+  signInAudience: AzureADMyOrg
+
+  # Enable ID token issuance (required for EasyAuth)
+  enableIdTokenIssuance: true
+
+specificConfig: []
+
+exports:
+  clientId: AzureADAppClientId

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
   "dependencies": {
     "commander": "^14.0.2",
     "execa": "^9.6.1",
+    "js-yaml": "^4.1.1",
     "yaml": "^2.8.2",
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.10.5",
     "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^9.18.0",

--- a/src/azure/authProvider.ts
+++ b/src/azure/authProvider.ts
@@ -1,12 +1,201 @@
-import { AuthProvider, Command, Dependency, Resource } from "../common/resource.js";
+import { AuthProvider, Command, Dependency, Resource, getRender } from "../common/resource.js";
+import { AzureResourceRender } from "./render.js";
+import { execSync } from "child_process";
 
+/**
+ * Supported role assignment scopes.
+ *
+ * - "resource": the role is assigned on the provider resource itself
+ *               (e.g. AcrPull on a specific ACR)
+ * - "resourceGroup": the role is assigned on the provider's resource group
+ * - "subscription": the role is assigned at the subscription level
+ */
+export type RoleAssignmentScope = 'resource' | 'resourceGroup' | 'subscription';
+
+/**
+ * AzureManagedIdentityAuthProvider
+ *
+ * Grants a role on the *provider* resource to the managed identity of the *requestor* resource.
+ *
+ * Expected args (from YAML authProvider config):
+ *   - role  (required): the Azure built-in or custom role name/id, e.g. "AcrPull"
+ *   - scope (optional): "resource" | "resourceGroup" | "subscription" (default: "resource")
+ *
+ * At deploy time the commands:
+ *   1. Fetch the requestor's system-assigned principal ID at runtime via envCapture.
+ *   2. Fetch the provider's resource scope (ARM resource ID or RG) at runtime via envCapture.
+ *   3. Run `az role assignment create` using both captured values.
+ *
+ * All lookups are deferred to shell commands so dry-run works even when
+ * resources don't exist yet.
+ */
 export class AzureManagedIdentityAuthProvider implements AuthProvider {
     name: string = 'AzureManagedIdentity';
 
     dependencies: Dependency[] = [];
 
     async apply(requestor: Resource, provider: Resource, args: Record<string, string>): Promise<Command[]> {
-        throw new Error(`not implemented yet`);
+        const role = args['role'];
+        if (!role) {
+            throw new Error(
+                `AzureManagedIdentityAuthProvider: 'role' is required in authProvider args ` +
+                `(requestor: ${requestor.type}.${requestor.name}, provider: ${provider.type}.${provider.name})`
+            );
+        }
+
+        const scopeMode: RoleAssignmentScope = (args['scope'] as RoleAssignmentScope) ?? 'resource';
+
+        const requestorRender = getRender(requestor.type) as AzureResourceRender;
+        const providerRender  = getRender(provider.type)  as AzureResourceRender;
+
+        // Shell variable name slug helper (uppercase, non-alphanumeric → underscore)
+        const slug = (s: string) => s.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+
+        const requestorSlug = slug(requestorRender.getResourceName(requestor));
+        const providerSlug  = slug(providerRender.getResourceName(provider));
+        const roleSlug      = slug(role);
+
+        const principalVar = `MERLIN_MI_${requestorSlug}_PRINCIPAL_ID`;
+        const scopeVar     = `MERLIN_MI_${providerSlug}_${roleSlug}_SCOPE`;
+
+        const commands: Command[] = [];
+
+        // ── Step 1: capture the requestor's managed identity principal ID ──────
+        commands.push(
+            ...this.buildPrincipalIdCapture(requestor, requestorRender, principalVar)
+        );
+
+        // ── Step 2: capture the provider resource's ARM scope ─────────────────
+        commands.push(
+            ...this.buildScopeCapture(provider, providerRender, scopeMode, scopeVar)
+        );
+
+        // ── Step 3: create the role assignment (idempotent) ───────────────────
+        // --assignee-object-id + --assignee-principal-type avoids AAD graph lookups
+        // and is more reliable in automation contexts.
+        commands.push({
+            command: 'az',
+            args: [
+                'role', 'assignment', 'create',
+                '--assignee-object-id', `$${principalVar}`,
+                '--assignee-principal-type', 'ServicePrincipal',
+                '--role', role,
+                '--scope', `$${scopeVar}`,
+            ],
+        });
+
+        return commands;
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Returns commands to capture the system-assigned managed identity principal ID
+     * of the requestor resource into `varName`.
+     *
+     * Strategy: use `az resource show` with a JMESPath query that works across
+     * resource types by fetching `identity.principalId`.  This is more reliable
+     * than `az ad sp list --filter` because:
+     *   - It requires no AAD Graph read permission.
+     *   - It directly returns the object ID without a name-based search.
+     *
+     * If the resource type has a dedicated `show` command registered via a
+     * known mapping we use that; otherwise we fall back to `az resource show`.
+     */
+    private buildPrincipalIdCapture(
+        requestor: Resource,
+        render: AzureResourceRender,
+        varName: string,
+    ): Command[] {
+        const resourceName  = render.getResourceName(requestor);
+        const resourceGroup = render.getResourceGroupName(requestor);
+
+        const showArgs = this.buildShowArgs(requestor.type, resourceName, resourceGroup);
+
+        return [{
+            command: 'az',
+            args: [...showArgs, '--query', 'identity.principalId', '-o', 'tsv'],
+            envCapture: varName,
+        }];
+    }
+
+    /**
+     * Returns commands to capture the ARM scope string for the provider resource
+     * into `varName`.  The scope depends on `scopeMode`:
+     *
+     * - "resource":      the full ARM resource ID of the provider
+     * - "resourceGroup": the resource group ARM ID (/subscriptions/.../resourceGroups/...)
+     * - "subscription":  the subscription ARM ID (/subscriptions/...)
+     */
+    private buildScopeCapture(
+        provider: Resource,
+        render: AzureResourceRender,
+        scopeMode: RoleAssignmentScope,
+        varName: string,
+    ): Command[] {
+        const resourceName  = render.getResourceName(provider);
+        const resourceGroup = render.getResourceGroupName(provider);
+
+        switch (scopeMode) {
+            case 'resource': {
+                // Full ARM resource ID via az <resource> show --query id
+                const showArgs = this.buildShowArgs(provider.type, resourceName, resourceGroup);
+                return [{
+                    command: 'az',
+                    args: [...showArgs, '--query', 'id', '-o', 'tsv'],
+                    envCapture: varName,
+                }];
+            }
+
+            case 'resourceGroup': {
+                // Resource group ARM ID
+                return [{
+                    command: 'az',
+                    args: [
+                        'group', 'show',
+                        '--name', resourceGroup,
+                        '--query', 'id',
+                        '-o', 'tsv',
+                    ],
+                    envCapture: varName,
+                }];
+            }
+
+            case 'subscription': {
+                // Subscription ARM ID
+                return [{
+                    command: 'az',
+                    args: [
+                        'account', 'show',
+                        '--query', 'id',
+                        '-o', 'tsv',
+                    ],
+                    envCapture: varName,
+                }];
+            }
+        }
+    }
+
+    /**
+     * Returns the `az` sub-command args (without --query/-o) for showing a
+     * resource of the given type.  Falls back to `az resource show` for unknown
+     * types so the auth provider works with any future resource type.
+     */
+    private buildShowArgs(resourceType: string, resourceName: string, resourceGroup: string): string[] {
+        const SHOW_COMMAND_MAP: Record<string, string[]> = {
+            'AzureContainerApp':         ['containerapp', 'show', '--name', resourceName, '--resource-group', resourceGroup],
+            'AzureContainerRegistry':    ['acr', 'show', '--name', resourceName, '--resource-group', resourceGroup],
+            'AzureContainerAppEnvironment': ['containerapp', 'env', 'show', '--name', resourceName, '--resource-group', resourceGroup],
+            'AzureLogAnalyticsWorkspace': ['monitor', 'log-analytics', 'workspace', 'show', '--name', resourceName, '--resource-group', resourceGroup],
+            'AzureBlobStorage':          ['storage', 'account', 'show', '--name', resourceName, '--resource-group', resourceGroup],
+        };
+
+        return SHOW_COMMAND_MAP[resourceType] ?? [
+            'resource', 'show',
+            '--name', resourceName,
+            '--resource-group', resourceGroup,
+            '--resource-type', resourceType,
+        ];
     }
 }
 

--- a/src/azure/azureADApp.ts
+++ b/src/azure/azureADApp.ts
@@ -51,6 +51,13 @@ export interface AzureADAppResource extends Resource<AzureADAppConfig> {}
 export class AzureADAppRender extends AzureResourceRender {
     supportConnectorInResourceName: boolean = true;
 
+    /**
+     * Azure AD Apps are tenant-scoped global resources — they have no region.
+     * Setting isGlobalResource = true allows region-aware resources (e.g. ACAs)
+     * to resolve an AD App dependency by ring only, ignoring region.
+     */
+    override isGlobalResource: boolean = true;
+
     override getShortResourceTypeName(): string {
         return 'aad';
     }

--- a/src/azure/azureContainerApp.ts
+++ b/src/azure/azureContainerApp.ts
@@ -2,6 +2,7 @@ import { AzureResource } from './resource.js';
 import { Resource, ResourceSchema, Command, RenderContext } from '../common/resource.js';
 import { AzureResourceRender } from './render.js';
 import { execSync } from 'child_process';
+import { dump as yamlDump } from 'js-yaml';
 
 export const AZURE_CONTAINER_APP_TYPE = 'AzureContainerApp';
 
@@ -21,6 +22,35 @@ export type DaprProtocol = 'grpc' | 'http';
 
 // Dapr log level
 export type DaprLogLevel = 'debug' | 'error' | 'info' | 'warn';
+
+// ── Health probe types ────────────────────────────────────────────────────────
+
+export type ProbeType = 'Liveness' | 'Readiness' | 'Startup';
+export type ProbeScheme = 'HTTP' | 'HTTPS';
+
+export interface HttpProbeConfig {
+    path: string;
+    port: number;
+    scheme?: ProbeScheme;
+    httpHeaders?: Array<{ name: string; value: string }>;
+}
+
+export interface TcpProbeConfig {
+    port: number;
+}
+
+export interface ContainerProbe {
+    type: ProbeType;
+    /** Specify exactly one of httpGet or tcpSocket */
+    httpGet?: HttpProbeConfig;
+    tcpSocket?: TcpProbeConfig;
+    initialDelaySeconds?: number;
+    periodSeconds?: number;
+    timeoutSeconds?: number;
+    failureThreshold?: number;
+    successThreshold?: number;
+}
+
 
 export interface AzureContainerAppConfig extends ResourceSchema {
     // ── Container / image ─────────────────────────────────────────────────────
@@ -110,6 +140,47 @@ export interface AzureContainerAppConfig extends ResourceSchema {
         /** 子域名前缀（例如 "myapp" 对应 "myapp.example.com"） */
         subDomain: string;
     };
+
+    // ── Health probes ──────────────────────────────────────────────────────────
+    /**
+     * Container health probe configuration.
+     * When set, renderCreate/renderUpdate will use --yaml mode because
+     * az containerapp create/update does not support probes via CLI flags.
+     * Supports Liveness, Readiness, and Startup probe types with either
+     * httpGet or tcpSocket checks.
+     */
+    probes?: ContainerProbe[];
+
+    // ── EasyAuth (Built-in Authentication) ────────────────────────────────────
+    /**
+     * Azure Container Apps built-in authentication (EasyAuth) configuration.
+     *
+     * Merlin will automatically:
+     *   1. Generate (or rotate) a client secret on the AD App via
+     *      `az ad app credential reset --append`
+     *   2. Store the secret value in an ACA secret named
+     *      `microsoft-provider-authentication-secret`
+     *   3. Update the AD App's webRedirectUris with the ACA callback URL
+     *   4. Enable EasyAuth on the Container App
+     *   5. Configure the Microsoft (AAD) identity provider
+     *
+     * The clientId is typically a ${ AzureADApp.<name>.clientId } expression
+     * resolved at deploy time.
+     */
+    auth?: {
+        /** Azure AD Application (client) ID. */
+        clientId: string;
+        /**
+         * OpenID Connect issuer URI.
+         * Default: https://sts.windows.net/<tenantId>/v2.0
+         */
+        issuer?: string;
+        /**
+         * Action for unauthenticated clients.
+         * Default: RedirectToLoginPage
+         */
+        unauthenticatedClientAction?: 'AllowAnonymous' | 'RedirectToLoginPage' | 'Return401' | 'Return403';
+    };
 }
 
 export interface AzureContainerAppResource extends AzureResource<AzureContainerAppConfig> {}
@@ -190,6 +261,9 @@ export class AzureContainerAppRender extends AzureResourceRender {
 
         // Post-deployment: bind custom DNS zone if configured
         ret.push(...this.renderBindDnsZone(resource as AzureContainerAppResource));
+
+        // Post-deployment: configure EasyAuth if configured
+        ret.push(...this.renderAuth(resource as AzureContainerAppResource));
 
         return ret;
     }
@@ -283,6 +357,30 @@ export class AzureContainerAppRender extends AzureResourceRender {
                 tags: d.tags,
 
                 // secrets: intentionally omitted — values are redacted in show output
+
+                // Probes
+                probes: Array.isArray(container?.probes)
+                    ? container.probes.map((p: Record<string, unknown>) => {
+                        const probe: ContainerProbe = { type: p.type as ProbeType };
+                        const httpGet = p.httpGet as Record<string, unknown> | undefined;
+                        const tcpSocket = p.tcpSocket as Record<string, unknown> | undefined;
+                        if (httpGet) {
+                            probe.httpGet = {
+                                path: httpGet.path as string,
+                                port: httpGet.port as number,
+                                scheme: httpGet.scheme as ProbeScheme | undefined,
+                            };
+                        } else if (tcpSocket) {
+                            probe.tcpSocket = { port: tcpSocket.port as number };
+                        }
+                        if (p.initialDelaySeconds !== undefined) probe.initialDelaySeconds = p.initialDelaySeconds as number;
+                        if (p.periodSeconds !== undefined) probe.periodSeconds = p.periodSeconds as number;
+                        if (p.timeoutSeconds !== undefined) probe.timeoutSeconds = p.timeoutSeconds as number;
+                        if (p.failureThreshold !== undefined) probe.failureThreshold = p.failureThreshold as number;
+                        if (p.successThreshold !== undefined) probe.successThreshold = p.successThreshold as number;
+                        return probe;
+                    })
+                    : undefined,
             };
 
             // Remove undefined values
@@ -325,15 +423,10 @@ export class AzureContainerAppRender extends AzureResourceRender {
         'minReplicas': '--min-replicas',
         'maxReplicas': '--max-replicas',
         'revisionSuffix': '--revision-suffix',
-        'revisionsMode': '--revisions-mode',
         'scaleRuleName': '--scale-rule-name',
         'scaleRuleType': '--scale-rule-type',
         'scaleRuleHttpConcurrency': '--scale-rule-http-concurrency',
         'secretVolumeMount': '--secret-volume-mount',
-        'registryServer': '--registry-server',
-        'registryUsername': '--registry-username',
-        'registryPassword': '--registry-password',
-        'registryIdentity': '--registry-identity',
         'daprAppId': '--dapr-app-id',
         'daprAppPort': '--dapr-app-port',
         'daprAppProtocol': '--dapr-app-protocol',
@@ -353,6 +446,12 @@ export class AzureContainerAppRender extends AzureResourceRender {
         'targetPort': '--target-port',
         'transport': '--transport',
         'exposedPort': '--exposed-port',
+        // Registry and revision mode are not supported by `az containerapp update`
+        'revisionsMode': '--revisions-mode',
+        'registryServer': '--registry-server',
+        'registryUsername': '--registry-username',
+        'registryPassword': '--registry-password',
+        'registryIdentity': '--registry-identity',
     };
 
     /**
@@ -375,7 +474,6 @@ export class AzureContainerAppRender extends AzureResourceRender {
      * Array params (space-joined) supported on BOTH create and update
      */
     private static readonly ARRAY_PARAM_MAP: Record<string, string> = {
-        'envVars': '--env-vars',
         'secrets': '--secrets',
         'scaleRuleMetadata': '--scale-rule-metadata',
         'scaleRuleAuth': '--scale-rule-auth',
@@ -388,13 +486,16 @@ export class AzureContainerAppRender extends AzureResourceRender {
         'args': '--args',
         'command': '--command',
         'userAssigned': '--user-assigned',
+        // --env-vars is not supported by `az containerapp update`
+        'envVars': '--env-vars',
     };
 
     // ── Render methods ────────────────────────────────────────────────────────
 
     renderCreate(resource: AzureContainerAppResource): Command[] {
-        const args: string[] = [];
         const config = resource.config;
+
+        const args: string[] = [];
 
         args.push('containerapp', 'create');
         args.push('--name', this.getResourceName(resource));
@@ -419,19 +520,29 @@ export class AzureContainerAppRender extends AzureResourceRender {
 
         this.addTags(args, config.tags);
 
-        return [{ command: 'az', args }];
+        const createCmd: Command = { command: 'az', args };
+
+        // When probes are configured, az containerapp create does not support probes via CLI flags.
+        // az containerapp create --yaml also cannot set probes reliably (managedEnvironmentId lookup
+        // issues). The solution: create with CLI flags first, then immediately update via --yaml to
+        // apply the probes. This is always safe because the update runs right after create.
+        if (config.probes && config.probes.length > 0) {
+            return [createCmd, ...this.renderUpdateViaYaml(resource)];
+        }
+
+        return [createCmd];
     }
 
     /**
-     * 生成 DNS Zone 绑定所需的命令序列。
-     * 若未配置 bindDnsZone 则返回空数组。
+     * Generates the command sequence for binding a custom DNS zone to a container app.
+     * Returns an empty array if bindDnsZone is not configured.
      *
-     * 所有动态参数（DNS Zone RG、Environment 名称、FQDN、验证 ID）均通过
-     * envCapture 机制在部署执行时捕获，render 阶段不执行任何 execSync 查询。
+     * All dynamic values (DNS Zone RG, Environment name, FQDN, verification ID) are
+     * captured at deploy time via envCapture — no execSync calls during render.
      *
-     * 注意：DNS 记录命令不是完全幂等的——
-     *   cname set-record 会覆盖已有 CNAME 值；
-     *   txt add-record 重复执行可能产生重复 TXT 记录。
+     * Note: DNS record commands are not fully idempotent:
+     *   cname set-record overwrites any existing CNAME value;
+     *   txt add-record may create duplicate TXT records on repeated runs.
      */
     private renderBindDnsZone(resource: AzureContainerAppResource): Command[] {
         const { bindDnsZone } = resource.config;
@@ -452,7 +563,7 @@ export class AzureContainerAppRender extends AzureResourceRender {
 
         const commands: Command[] = [];
 
-        // ── 步骤 0a：查询 DNS Zone 所在 Resource Group ──────────────────────
+        // ── Step 0a: Look up the DNS Zone resource group ─────────────────────
         commands.push({
             command: 'az',
             args: [
@@ -463,7 +574,7 @@ export class AzureContainerAppRender extends AzureResourceRender {
             envCapture: dnsZoneRgVar,
         });
 
-        // ── 步骤 0b：查询 Container Environment 的完整 ARM resource ID ──────
+        // ── Step 0b: Look up the Container Environment ARM resource ID ────────
         commands.push({
             command: 'az',
             args: [
@@ -476,16 +587,29 @@ export class AzureContainerAppRender extends AzureResourceRender {
             envCapture: envArmIdVar,
         });
 
-        // ── 步骤 0c：从 ARM ID 提取 Environment 名称（最后一段）─────────────
-        // ARM ID 格式：.../providers/Microsoft.App/managedEnvironments/<env-name>
-        // Merlin 只支持简单 $VARNAME 替换，不支持 bash 参数展开，故用独立 bash 命令处理
+        // ── Step 0c: Extract environment name from ARM ID (last path segment) ─
+        // ARM ID format: .../providers/Microsoft.App/managedEnvironments/<env-name>
+        // Merlin only supports simple $VARNAME substitution, not bash parameter expansion,
+        // so we use a separate bash command to extract the last segment.
         commands.push({
             command: 'bash',
             args: ['-c', `echo $${envArmIdVar} | sed 's|.*/||'`],
             envCapture: envNameVar,
         });
 
-        // ── 步骤 1：获取容器应用默认域名（FQDN）────────────────────────────
+        // ── Step 1: Register the hostname on the container app (no certificate yet) ─
+        // Azure requires the hostname to be added to the container app before a managed
+        // certificate can be requested. This step does not need any DNS records.
+        // Use bash to swallow the "already exists" error — idempotent on re-runs.
+        commands.push({
+            command: 'bash',
+            args: [
+                '-c',
+                `az containerapp hostname add --hostname ${subDomain}.${dnsZone} --name ${resourceName} --resource-group ${resourceGroup} || true`,
+            ],
+        });
+
+        // ── Step 2: Capture the container app's default ingress FQDN ─────────
         commands.push({
             command: 'az',
             args: [
@@ -498,7 +622,7 @@ export class AzureContainerAppRender extends AzureResourceRender {
             envCapture: fqdnVar,
         });
 
-        // ── 步骤 2：在 DNS Zone 中创建 CNAME 记录 ───────────────────────────
+        // ── Step 3: Create CNAME record in the DNS zone ───────────────────────
         commands.push({
             command: 'az',
             args: [
@@ -510,7 +634,7 @@ export class AzureContainerAppRender extends AzureResourceRender {
             ],
         });
 
-        // ── 步骤 3：获取自定义域名验证 ID ───────────────────────────────────
+        // ── Step 4: Capture the custom domain verification ID ─────────────────
         commands.push({
             command: 'az',
             args: [
@@ -523,7 +647,7 @@ export class AzureContainerAppRender extends AzureResourceRender {
             envCapture: verificationVar,
         });
 
-        // ── 步骤 4：创建 TXT 验证记录（asuid.<subDomain>）───────────────────
+        // ── Step 5: Create TXT verification record (asuid.<subDomain>) ────────
         commands.push({
             command: 'az',
             args: [
@@ -535,24 +659,22 @@ export class AzureContainerAppRender extends AzureResourceRender {
             ],
         });
 
-        // ── 等待 DNS 传播 ─────────────────────────────────────────────────────
-        // Azure DNS 控制平面返回 "Succeeded" 后，权威 DNS 服务器之间的同步
-        // 仍需数秒到数十秒，必须等待传播完成后再执行 hostname bind 验证。
+        // ── Wait for DNS propagation ──────────────────────────────────────────
+        // After Azure DNS returns "Succeeded", authoritative name servers need
+        // a few seconds to sync. Wait before running hostname bind validation.
         commands.push({
             command: 'bash',
             args: ['-c', 'sleep 30'],
         });
 
-        // ── 步骤 5：将自定义域名绑定到容器应用 ──────────────────────────────
+        // ── Step 6: Bind the hostname and request a managed certificate ────────
+        // Use || true to make this idempotent — if the hostname is already bound
+        // (certificate already issued), Azure returns an error we can safely ignore.
         commands.push({
-            command: 'az',
+            command: 'bash',
             args: [
-                'containerapp', 'hostname', 'bind',
-                '--hostname',          `${subDomain}.${dnsZone}`,
-                '--resource-group',    resourceGroup,
-                '--name',              resourceName,
-                '--environment',       `$${envNameVar}`,
-                '--validation-method', 'CNAME',
+                '-c',
+                `az containerapp hostname bind --hostname ${subDomain}.${dnsZone} --resource-group ${resourceGroup} --name ${resourceName} --environment $${envNameVar} --validation-method CNAME || true`,
             ],
         });
 
@@ -560,8 +682,14 @@ export class AzureContainerAppRender extends AzureResourceRender {
     }
 
     renderUpdate(resource: AzureContainerAppResource): Command[] {
-        const args: string[] = [];
         const config = resource.config;
+
+        // When probes are configured, use --yaml mode (CLI doesn't support probes directly)
+        if (config.probes && config.probes.length > 0) {
+            return this.renderUpdateViaYaml(resource);
+        }
+
+        const args: string[] = [];
 
         args.push('containerapp', 'update');
         args.push('--name', this.getResourceName(resource));
@@ -580,4 +708,242 @@ export class AzureContainerAppRender extends AzureResourceRender {
 
         return [{ command: 'az', args }];
     }
+
+    // ── EasyAuth render ───────────────────────────────────────────────────────
+
+    /**
+     * Renders EasyAuth (built-in authentication) commands.
+     *
+     * Steps emitted:
+     *   1. Generate (or rotate) a client secret on the AD App and capture the value
+     *   2. Store the secret value as an ACA secret
+     *   3. Update the AD App's webRedirectUris with the ACA callback URL
+     *   4. az containerapp auth update  — enable auth + set unauthenticated action
+     *   5. az containerapp auth microsoft update  — configure AAD identity provider
+     *
+     * All dynamic values (FQDN, client secret) are resolved at deploy time via
+     * envCapture, so this is safe to re-run on both create and update paths.
+     */
+    private renderAuth(resource: AzureContainerAppResource): Command[] {
+        const { auth } = resource.config;
+        if (!auth) return [];
+
+        const resourceName  = this.getResourceName(resource);
+        const resourceGroup = this.getResourceGroupName(resource);
+        const action = auth.unauthenticatedClientAction ?? 'RedirectToLoginPage';
+        const secretName = 'microsoft-provider-authentication-secret';
+
+        const slug = (s: string) => s.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+        const appSlug      = slug(resourceName);
+        const fqdnVar      = `MERLIN_${appSlug}_AUTH_FQDN`;
+        const secretValVar = `MERLIN_${appSlug}_AUTH_SECRET`;
+
+        return [
+            // Step 1: generate (append) a new client secret on the AD App
+            {
+                command: 'az',
+                args: [
+                    'ad', 'app', 'credential', 'reset',
+                    '--id',          auth.clientId,
+                    '--append',
+                    '--display-name', `merlin-easyauth-${resourceName}`,
+                    '--query',        'password',
+                    '-o',             'tsv',
+                ],
+                envCapture: secretValVar,
+            },
+            // Step 2: store the secret value in the ACA
+            {
+                command: 'az',
+                args: [
+                    'containerapp', 'secret', 'set',
+                    '--name',           resourceName,
+                    '--resource-group', resourceGroup,
+                    '--secrets',        `${secretName}=$${secretValVar}`,
+                ],
+            },
+            // Step 3: get the ACA FQDN for the redirect URI
+            {
+                command: 'az',
+                args: [
+                    'containerapp', 'show',
+                    '--name',           resourceName,
+                    '--resource-group', resourceGroup,
+                    '--query',          'properties.configuration.ingress.fqdn',
+                    '-o',               'tsv',
+                ],
+                envCapture: fqdnVar,
+            },
+            // Step 4: update the AD App's webRedirectUris
+            {
+                command: 'az',
+                args: [
+                    'ad', 'app', 'update',
+                    '--id',               auth.clientId,
+                    '--web-redirect-uris', `https://$${fqdnVar}/.auth/login/aad/callback`,
+                ],
+            },
+            // Step 5: enable auth platform + set unauthenticated action
+            {
+                command: 'az',
+                args: [
+                    'containerapp', 'auth', 'update',
+                    '--name',           resourceName,
+                    '--resource-group', resourceGroup,
+                    '--enabled',        'true',
+                    '--action',         action,
+                ],
+            },
+            // Step 6: configure Microsoft (AAD) identity provider
+            {
+                command: 'az',
+                args: [
+                    'containerapp', 'auth', 'microsoft', 'update',
+                    '--name',               resourceName,
+                    '--resource-group',     resourceGroup,
+                    '--client-id',          auth.clientId,
+                    '--client-secret-name', secretName,
+                    ...(auth.issuer ? ['--issuer', auth.issuer] : []),
+                ],
+            },
+        ];
+    }
+
+    // ── YAML-based render (for probe support) ────────────────────────────────
+
+    /**
+     * Renders an `az containerapp update --yaml` command.
+     * Used when probes are configured.
+     */
+    private renderUpdateViaYaml(resource: AzureContainerAppResource): Command[] {
+        const fileContent = this.buildContainerAppYaml(resource);
+        return [{
+            command: 'az',
+            args: [
+                'containerapp', 'update',
+                '--name',           this.getResourceName(resource),
+                '--resource-group', this.getResourceGroupName(resource),
+                '--yaml',           '__MERLIN_YAML_FILE__',
+                ...(resource.config.noWait ? ['--no-wait'] : []),
+            ],
+            fileContent,
+        }];
+    }
+
+    /**
+     * Serializes the resource config to the YAML format expected by
+     * `az containerapp update --yaml`.
+     *
+     * Only includes fields relevant to update: container template (image, resources,
+     * env vars, probes) and scale. Ingress, registry, and identity are create-only
+     * and handled via CLI flags in renderCreate().
+     */
+    private buildContainerAppYaml(resource: AzureContainerAppResource): string {
+        const config = resource.config;
+        const resourceName = this.getResourceName(resource);
+
+        // ── containers[0] ──
+        const container: Record<string, unknown> = {
+            name: config.containerName ?? resourceName,
+        };
+
+        if (config.image !== undefined) container.image = config.image;
+
+        if (config.cpu !== undefined) {
+            container.resources = { cpu: config.cpu, memory: config.memory };
+        }
+
+        if (config.envVars && config.envVars.length > 0) {
+            container.env = config.envVars.map((ev: string) => {
+                const sepIdx = ev.indexOf('=');
+                const name = ev.slice(0, sepIdx);
+                const rawValue = ev.slice(sepIdx + 1);
+                if (rawValue.startsWith('secretref:')) {
+                    return { name, secretRef: rawValue.slice('secretref:'.length) };
+                }
+                return { name, value: rawValue };
+            });
+        }
+
+        if (config.probes && config.probes.length > 0) {
+            container.probes = config.probes.map(p => this.buildProbeYaml(p));
+        }
+
+        // ── template ──
+        const template: Record<string, unknown> = { containers: [container] };
+
+        if (config.minReplicas !== undefined || config.maxReplicas !== undefined) {
+            template.scale = {
+                ...(config.minReplicas !== undefined && { minReplicas: config.minReplicas }),
+                ...(config.maxReplicas !== undefined && { maxReplicas: config.maxReplicas }),
+            };
+        }
+
+        if (config.terminationGracePeriod !== undefined) {
+            template.terminationGracePeriodSeconds = config.terminationGracePeriod;
+        }
+
+        // ── configuration (revision mode only for update) ──
+        const configuration: Record<string, unknown> = {};
+
+        if (config.revisionsMode) {
+            configuration.activeRevisionsMode =
+                config.revisionsMode === 'single' ? 'Single' : 'Multiple';
+        }
+
+        if (config.secrets && config.secrets.length > 0) {
+            configuration.secrets = config.secrets.map((s: string) => {
+                const eqIdx = s.indexOf('=');
+                return { name: s.slice(0, eqIdx), value: s.slice(eqIdx + 1) };
+            });
+        }
+
+        if (config.enableDapr !== undefined) {
+            configuration.dapr = {
+                enabled: config.enableDapr,
+                ...(config.daprAppId && { appId: config.daprAppId }),
+                ...(config.daprAppPort !== undefined && { appPort: config.daprAppPort }),
+                ...(config.daprAppProtocol && { appProtocol: config.daprAppProtocol }),
+            };
+        }
+
+        // ── top-level document ──
+        const properties: Record<string, unknown> = {
+            ...(Object.keys(configuration).length > 0 && { configuration }),
+            template,
+        };
+
+        const doc: Record<string, unknown> = { properties };
+
+        if (config.tags && Object.keys(config.tags).length > 0) {
+            doc.tags = config.tags;
+        }
+
+        return yamlDump(doc, { lineWidth: -1, noRefs: true });
+    }
+
+    /** Serializes a single ContainerProbe to the Azure ARM YAML format. */
+    private buildProbeYaml(probe: ContainerProbe): Record<string, unknown> {
+        const result: Record<string, unknown> = { type: probe.type };
+
+        if (probe.httpGet) {
+            result.httpGet = {
+                path: probe.httpGet.path,
+                port: probe.httpGet.port,
+                scheme: probe.httpGet.scheme ?? 'HTTP',
+                ...(probe.httpGet.httpHeaders && { httpHeaders: probe.httpGet.httpHeaders }),
+            };
+        } else if (probe.tcpSocket) {
+            result.tcpSocket = { port: probe.tcpSocket.port };
+        }
+
+        if (probe.initialDelaySeconds !== undefined) result.initialDelaySeconds = probe.initialDelaySeconds;
+        if (probe.periodSeconds       !== undefined) result.periodSeconds       = probe.periodSeconds;
+        if (probe.timeoutSeconds      !== undefined) result.timeoutSeconds      = probe.timeoutSeconds;
+        if (probe.failureThreshold    !== undefined) result.failureThreshold    = probe.failureThreshold;
+        if (probe.successThreshold    !== undefined) result.successThreshold    = probe.successThreshold;
+
+        return result;
+    }
+
 }

--- a/src/azure/azureContainerAppEnvironment.ts
+++ b/src/azure/azureContainerAppEnvironment.ts
@@ -246,6 +246,11 @@ export class AzureContainerAppEnvironmentRender extends AzureResourceRender {
         this.addSimpleParams(args, config, AzureContainerAppEnvironmentRender.SIMPLE_PARAM_MAP);
         this.addBooleanFlags(args, config, AzureContainerAppEnvironmentRender.BOOLEAN_FLAG_MAP);
 
+        // Azure CLI requires --logs-destination log-analytics when --logs-workspace-id/key are provided on update
+        if (config.logsWorkspaceId && !config.logsDestination) {
+            args.push('--logs-destination', 'log-analytics');
+        }
+
         if (config.noWait === true) {
             args.push('--no-wait');
         }

--- a/src/azure/azureContainerRegistry.ts
+++ b/src/azure/azureContainerRegistry.ts
@@ -297,6 +297,7 @@ export class AzureContainerRegistryRender extends AzureResourceRender {
                             '--name', registryName,
                             '--source', image.source,
                             '--image', `${image.name}:${tag}`,
+                            '--force',
                         ]
                     });
                 }

--- a/src/azure/azureDnsZone.ts
+++ b/src/azure/azureDnsZone.ts
@@ -217,19 +217,122 @@ export class AzureDnsZoneRender extends AzureResourceRender {
     }
 
     renderCreate(resource: AzureDnsZoneResource): Command[] {
-        const args: string[] = [];
         const config = resource.config;
+        const commands: Command[] = [];
 
-        // Base command
-        args.push('network', 'dns', 'zone', 'create');
+        // ── Step 1: Create the DNS zone ───────────────────────────────────────
+        const createArgs: string[] = [];
+        createArgs.push('network', 'dns', 'zone', 'create');
+        createArgs.push('--name', this.getDnsZoneName(resource));
+        createArgs.push('--resource-group', this.getResourceGroupName(resource));
+        this.addTags(createArgs, config.tags);
+        commands.push({ command: 'az', args: createArgs });
 
-        // --name uses the actual DNS zone name (e.g. "chuangdns.thebrainly.dev")
-        args.push('--name', this.getDnsZoneName(resource));
-        args.push('--resource-group', this.getResourceGroupName(resource));
+        // ── Step 2: NS delegation into parent zone (only when parentName is set) ──
+        // After creation, Azure assigns 4 nameservers to the new zone.
+        // We query them at deploy time and write NS records into the parent zone
+        // so that global DNS resolvers can find the child zone.
+        if (config.parentName) {
+            commands.push(...this.renderNsDelegation(resource));
+        }
 
-        this.addTags(args, config.tags);
+        return commands;
+    }
 
-        return [{ command: 'az', args }];
+    /**
+     * Generates commands to delegate the newly created child DNS zone into its
+     * parent zone via NS records.
+     *
+     * Flow:
+     *   1. Capture the 4 Azure-assigned nameservers of the child zone into env vars
+     *   2. Look up the resource group that owns the parent zone (unknown ahead of time)
+     *   3. Create an NS record-set in the parent zone pointing to the child's nameservers
+     *
+     * All dynamic values are resolved at deploy time via envCapture — no execSync calls.
+     */
+    private renderNsDelegation(resource: AzureDnsZoneResource): Command[] {
+        const { dnsName, parentName } = resource.config;
+        if (!parentName) return [];
+
+        const childZoneName = this.getDnsZoneName(resource);
+        const childResourceGroup = this.getResourceGroupName(resource);
+
+        // Slug helper: uppercase, non-alphanumeric → underscore (mirrors paramResolver.ts toVarName)
+        const slug = (s: string) => s.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+        const zoneSlug = slug(childZoneName);
+
+        // Variable names for captured values
+        const ns1Var = `MERLIN_${zoneSlug}_NS1`;
+        const ns2Var = `MERLIN_${zoneSlug}_NS2`;
+        const ns3Var = `MERLIN_${zoneSlug}_NS3`;
+        const ns4Var = `MERLIN_${zoneSlug}_NS4`;
+        const parentRgVar = `MERLIN_${zoneSlug}_PARENT_RG`;
+
+        const commands: Command[] = [];
+
+        // ── Capture child zone's 4 nameservers ────────────────────────────────
+        // az network dns zone show returns nameServers as a JSON array;
+        // --query uses JMESPath index expressions to pick each one.
+        for (const [varName, index] of [
+            [ns1Var, 0], [ns2Var, 1], [ns3Var, 2], [ns4Var, 3],
+        ] as [string, number][]) {
+            commands.push({
+                command: 'az',
+                args: [
+                    'network', 'dns', 'zone', 'show',
+                    '--name', childZoneName,
+                    '--resource-group', childResourceGroup,
+                    '--query', `nameServers[${index}]`,
+                    '--output', 'tsv',
+                ],
+                envCapture: varName,
+            });
+        }
+
+        // ── Capture parent zone's resource group ──────────────────────────────
+        // The parent zone may live in a different resource group; look it up by name.
+        commands.push({
+            command: 'az',
+            args: [
+                'network', 'dns', 'zone', 'list',
+                '--query', `[?name=='${parentName}'].resourceGroup`,
+                '--output', 'tsv',
+            ],
+            envCapture: parentRgVar,
+        });
+
+        // ── Write NS record-set into the parent zone ──────────────────────────
+        // `dns record-set ns create` is idempotent (overwrites existing record-set).
+        // The record-set name is the relative label of the child zone within the parent,
+        // e.g. for child "chuang.staging.thebrainly.dev" and parent "thebrainly.dev"
+        // the relative label is "chuang.staging".
+        const relativeLabel = dnsName; // dnsName is already the part before parentName
+        commands.push({
+            command: 'az',
+            args: [
+                'network', 'dns', 'record-set', 'ns', 'create',
+                '--zone-name', parentName,
+                '--resource-group', `$${parentRgVar}`,
+                '--name', relativeLabel,
+                '--ttl', '3600',
+            ],
+        });
+
+        // Add each captured nameserver as an NS record entry
+        for (const nsVar of [ns1Var, ns2Var, ns3Var, ns4Var]) {
+            commands.push({
+                command: 'az',
+                args: [
+                    'network', 'dns', 'record-set', 'ns', 'add-record',
+                    '--zone-name', parentName,
+                    '--resource-group', `$${parentRgVar}`,
+                    '--record-set-name', relativeLabel,
+                    '--nsdname', `$${nsVar}`,
+                ],
+            });
+        }
+
+        return commands;
     }
 
     renderUpdate(resource: AzureDnsZoneResource): Command[] {

--- a/src/azure/azureLogAnalyticsWorkspace.ts
+++ b/src/azure/azureLogAnalyticsWorkspace.ts
@@ -168,7 +168,6 @@ export class AzureLogAnalyticsWorkspaceRender extends AzureResourceRender {
      * Parameters valid on both create and update
      */
     private static readonly SIMPLE_PARAM_MAP: Record<string, string> = {
-        'location':                  '--location',
         'retentionInDays':           '--retention-time',
         'dailyQuotaGb':              '--quota',
         'capacityReservationLevel':  '--capacity-reservation-level',
@@ -179,10 +178,11 @@ export class AzureLogAnalyticsWorkspaceRender extends AzureResourceRender {
     };
 
     /**
-     * Parameters valid on CREATE only — --sku is immutable after creation
+     * Parameters valid on CREATE only — --sku and --location are immutable after creation
      */
     private static readonly CREATE_ONLY_SIMPLE_PARAM_MAP: Record<string, string> = {
-        'sku': '--sku',
+        'sku':      '--sku',
+        'location': '--location',
     };
 
     /**

--- a/src/azure/proprietyGetter.ts
+++ b/src/azure/proprietyGetter.ts
@@ -1,6 +1,8 @@
 import { Command, Dependency, ProprietyGetter, Resource, getRender } from "../common/resource.js";
+import { resolveConfig } from "../common/paramResolver.js";
 import { AzureResourceRender } from "./render.js";
 import { AzureDnsZoneRender, AzureDnsZoneResource } from "./azureDnsZone.js";
+import { AzureADAppRender, AzureADAppResource } from "./azureADApp.js";
 
 /**
  * ProprietyGetter for Azure Resource Managed Identity,
@@ -133,6 +135,33 @@ export class AzureLogAnalyticsWorkspaceSharedKeyGetter implements ProprietyGette
                 '-g', resourceGroup,
                 '-o', 'tsv',
                 '--query', 'primarySharedKey'
+            ]
+        }];
+    }
+}
+
+/**
+ * ProprietyGetter for Azure AD App client ID (appId).
+ * Returns the appId (client ID) of the Azure AD application by display name.
+ */
+export class AzureADAppClientIdGetter implements ProprietyGetter {
+    name: string = 'AzureADAppClientId';
+
+    dependencies: Dependency[] = [];
+
+    async get(resource: Resource, _args: Record<string, string>): Promise<Command[]> {
+        const render = getRender(resource.type) as AzureADAppRender;
+        // config.displayName may be an unresolved param expression — resolve it first.
+        const { resource: resolved } = await resolveConfig(resource as AzureADAppResource);
+        const displayName = render.getDisplayName(resolved as AzureADAppResource);
+
+        return [{
+            command: 'az',
+            args: [
+                'ad', 'app', 'list',
+                '--filter', `displayName eq '${displayName}'`,
+                '-o', 'tsv',
+                '--query', '[0].appId'
             ]
         }];
     }

--- a/src/azure/test/authProvider.test.ts
+++ b/src/azure/test/authProvider.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AzureManagedIdentityAuthProvider } from '../authProvider.js';
+import * as resourceModule from '../../common/resource.js';
+import type { Resource, Render } from '../../common/resource.js';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeRender(resourceName: string, resourceGroupName: string): Render & { getResourceName: any; getResourceGroupName: any } {
+    return {
+        render: vi.fn(),
+        getShortResourceTypeName: vi.fn().mockReturnValue('acr'),
+        getResourceName: vi.fn().mockReturnValue(resourceName),
+        getResourceGroupName: vi.fn().mockReturnValue(resourceGroupName),
+    } as any;
+}
+
+function makeResource(type: string, name: string, ring = 'staging', region = 'eastasia'): Resource {
+    return {
+        name,
+        type,
+        ring: ring as any,
+        region: region as any,
+        project: 'merlintest',
+        dependencies: [],
+        config: {},
+        exports: {},
+    };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('AzureManagedIdentityAuthProvider', () => {
+    let provider: AzureManagedIdentityAuthProvider;
+
+    beforeEach(() => {
+        provider = new AzureManagedIdentityAuthProvider();
+        vi.restoreAllMocks();
+    });
+
+    it('name is AzureManagedIdentity', () => {
+        expect(provider.name).toBe('AzureManagedIdentity');
+    });
+
+    it('throws when role arg is missing', async () => {
+        const requestor = makeResource('AzureContainerApp', 'myaca');
+        const prov = makeResource('AzureContainerRegistry', 'myacr');
+
+        vi.spyOn(resourceModule, 'getRender').mockReturnValue(makeRender('mymyacrstgeasacr', 'merlintest-rg-stg-eas') as any);
+
+        await expect(provider.apply(requestor, prov, {})).rejects.toThrow("'role' is required");
+    });
+
+    describe('scope: resource (default)', () => {
+        beforeEach(() => {
+            vi.spyOn(resourceModule, 'getRender').mockImplementation((type: string) => {
+                if (type === 'AzureContainerApp') {
+                    return makeRender('merlintest-alluneed-stg-eas-aca', 'merlintest-rg-stg-eas') as any;
+                }
+                return makeRender('merlintestalluneedstgeasacr', 'merlintest-rg-stg-eas') as any;
+            });
+        });
+
+        it('returns 3 commands: principal capture, scope capture, role assignment', async () => {
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'AcrPull' });
+
+            expect(cmds).toHaveLength(3);
+        });
+
+        it('step 1 captures principal ID via containerapp show --query identity.principalId', async () => {
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'AcrPull' });
+
+            const captureCmd = cmds[0];
+            expect(captureCmd.envCapture).toMatch(/^MERLIN_MI_.*_PRINCIPAL_ID$/);
+            expect(captureCmd.command).toBe('az');
+            expect(captureCmd.args).toContain('containerapp');
+            expect(captureCmd.args).toContain('show');
+            expect(captureCmd.args).toContain('identity.principalId');
+        });
+
+        it('step 2 captures scope via acr show --query id', async () => {
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'AcrPull' });
+
+            const scopeCmd = cmds[1];
+            expect(scopeCmd.envCapture).toMatch(/^MERLIN_MI_.*_SCOPE$/);
+            expect(scopeCmd.command).toBe('az');
+            expect(scopeCmd.args).toContain('acr');
+            expect(scopeCmd.args).toContain('show');
+            expect(scopeCmd.args).toContain('id');
+        });
+
+        it('step 3 runs az role assignment create with captured var references', async () => {
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'AcrPull' });
+
+            const principalVar = cmds[0].envCapture!;
+            const scopeVar     = cmds[1].envCapture!;
+            const roleCmd      = cmds[2];
+
+            expect(roleCmd.command).toBe('az');
+            expect(roleCmd.args).toContain('role');
+            expect(roleCmd.args).toContain('assignment');
+            expect(roleCmd.args).toContain('create');
+            expect(roleCmd.args).toContain('AcrPull');
+            expect(roleCmd.args).toContain(`$${principalVar}`);
+            expect(roleCmd.args).toContain(`$${scopeVar}`);
+            // Must include --assignee-principal-type for reliability in automation
+            expect(roleCmd.args).toContain('--assignee-principal-type');
+            expect(roleCmd.args).toContain('ServicePrincipal');
+        });
+
+        it('no command has fileContent or envCapture on the role assignment step', async () => {
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'AcrPull' });
+
+            expect(cmds[2].envCapture).toBeUndefined();
+            expect(cmds[2].fileContent).toBeUndefined();
+        });
+    });
+
+    describe('scope: resourceGroup', () => {
+        it('step 2 captures scope via az group show --query id', async () => {
+            vi.spyOn(resourceModule, 'getRender').mockImplementation((type: string) => {
+                if (type === 'AzureContainerApp') {
+                    return makeRender('merlintest-alluneed-stg-eas-aca', 'merlintest-rg-stg-eas') as any;
+                }
+                return makeRender('merlintestalluneedstgeasacr', 'merlintest-rg-stg-eas') as any;
+            });
+
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'Contributor', scope: 'resourceGroup' });
+
+            const scopeCmd = cmds[1];
+            expect(scopeCmd.args).toContain('group');
+            expect(scopeCmd.args).toContain('show');
+            expect(scopeCmd.args).toContain('--name');
+            expect(scopeCmd.args).toContain('merlintest-rg-stg-eas');
+        });
+    });
+
+    describe('scope: subscription', () => {
+        it('step 2 captures scope via az account show --query id', async () => {
+            vi.spyOn(resourceModule, 'getRender').mockImplementation((type: string) => {
+                if (type === 'AzureContainerApp') {
+                    return makeRender('merlintest-alluneed-stg-eas-aca', 'merlintest-rg-stg-eas') as any;
+                }
+                return makeRender('merlintestalluneedstgeasacr', 'merlintest-rg-stg-eas') as any;
+            });
+
+            const requestor = makeResource('AzureContainerApp', 'alluneed');
+            const prov      = makeResource('AzureContainerRegistry', 'alluneed');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'Owner', scope: 'subscription' });
+
+            const scopeCmd = cmds[1];
+            expect(scopeCmd.args).toContain('account');
+            expect(scopeCmd.args).toContain('show');
+            // No --name for subscription scope
+            expect(scopeCmd.args).not.toContain('--name');
+        });
+    });
+
+    describe('unknown resource type falls back to az resource show', () => {
+        it('uses az resource show for unrecognised provider type', async () => {
+            vi.spyOn(resourceModule, 'getRender').mockImplementation((type: string) => {
+                if (type === 'AzureContainerApp') {
+                    return makeRender('my-aca', 'my-rg') as any;
+                }
+                // Unknown type
+                return makeRender('my-custom-resource', 'my-rg') as any;
+            });
+
+            const requestor = makeResource('AzureContainerApp', 'myapp');
+            const prov      = makeResource('SomeUnknownType', 'myresource');
+
+            const cmds = await provider.apply(requestor, prov, { role: 'Reader', scope: 'resource' });
+
+            const scopeCmd = cmds[1];
+            expect(scopeCmd.args).toContain('resource');
+            expect(scopeCmd.args).toContain('show');
+            expect(scopeCmd.args).toContain('--resource-type');
+        });
+    });
+
+    describe('principal variable naming is deterministic', () => {
+        it('two different requestors produce different principal var names', async () => {
+            const mockRenderA = makeRender('merlintest-app-a-stg-eas-aca', 'merlintest-rg-stg-eas');
+            const mockRenderB = makeRender('merlintest-app-b-stg-eas-aca', 'merlintest-rg-stg-eas');
+            const mockRenderAcr = makeRender('merlintestappastgeasacr', 'merlintest-rg-stg-eas');
+
+            const requestorA = makeResource('AzureContainerApp', 'app-a');
+            const requestorB = makeResource('AzureContainerApp', 'app-b');
+            const prov       = makeResource('AzureContainerRegistry', 'myacr');
+
+            vi.spyOn(resourceModule, 'getRender').mockReturnValue(mockRenderAcr as any);
+
+            vi.spyOn(resourceModule, 'getRender')
+                .mockImplementationOnce(() => mockRenderA as any)
+                .mockImplementation(() => mockRenderAcr as any);
+            const cmdsA = await provider.apply(requestorA, prov, { role: 'AcrPull' });
+
+            vi.spyOn(resourceModule, 'getRender')
+                .mockImplementationOnce(() => mockRenderB as any)
+                .mockImplementation(() => mockRenderAcr as any);
+            const cmdsB = await provider.apply(requestorB, prov, { role: 'AcrPull' });
+
+            expect(cmdsA[0].envCapture).not.toBe(cmdsB[0].envCapture);
+        });
+    });
+});

--- a/src/azure/test/azureContainerApp.test.ts
+++ b/src/azure/test/azureContainerApp.test.ts
@@ -822,7 +822,8 @@ describe('AzureContainerAppRender', () => {
             const commands = await render.render(resource as unknown as Resource);
 
             const createIdx = commands.findIndex(c => c.args[0] === 'containerapp' && c.args[1] === 'create');
-            const bindIdx   = commands.findIndex(c => c.args[0] === 'containerapp' && c.args[1] === 'hostname');
+            // hostname bind is now emitted as: bash -c 'az containerapp hostname bind ...'
+            const bindIdx   = commands.findIndex(c => c.command === 'bash' && c.args[1]?.includes('hostname bind'));
             expect(createIdx).not.toBe(-1);
             expect(bindIdx).not.toBe(-1);
             expect(bindIdx).toBeGreaterThan(createIdx);
@@ -839,7 +840,8 @@ describe('AzureContainerAppRender', () => {
             const commands = await render.render(resource as unknown as Resource);
 
             const updateIdx = commands.findIndex(c => c.args[0] === 'containerapp' && c.args[1] === 'update');
-            const bindIdx   = commands.findIndex(c => c.args[0] === 'containerapp' && c.args[1] === 'hostname');
+            // hostname bind is now emitted as: bash -c 'az containerapp hostname bind ...'
+            const bindIdx   = commands.findIndex(c => c.command === 'bash' && c.args[1]?.includes('hostname bind'));
             expect(updateIdx).not.toBe(-1);
             expect(bindIdx).not.toBe(-1);
             expect(bindIdx).toBeGreaterThan(updateIdx);
@@ -971,19 +973,18 @@ describe('AzureContainerAppRender', () => {
             const resource = makeResourceWithDns('example.com', 'myapp');
             const commands = await render.render(resource as unknown as Resource);
 
+            // hostname bind is emitted as: bash -c 'az containerapp hostname bind --hostname ... --validation-method CNAME || true'
             const cmd = commands.find(c =>
-                c.command === 'az' &&
-                c.args[0] === 'containerapp' &&
-                c.args[1] === 'hostname' &&
-                c.args[2] === 'bind'
+                c.command === 'bash' &&
+                c.args[1]?.includes('hostname bind')
             );
             expect(cmd).toBeDefined();
-            expect(hasParam(cmd!.args, '--hostname', 'myapp.example.com')).toBe(true);
-            expect(hasParam(cmd!.args, '--resource-group', 'myproject-rg-stg-eus')).toBe(true);
-            expect(hasParam(cmd!.args, '--name', 'myproject-myapp-stg-eus-aca')).toBe(true);
-            expect(hasParam(cmd!.args, '--environment', `$${ENV_NAME_VAR}`)).toBe(true);
-            expect(hasParam(cmd!.args, '--validation-method', 'CNAME')).toBe(true);
-            expect(cmd!.envCapture).toBeUndefined();
+            const script = cmd!.args[1];
+            expect(script).toContain('--hostname myapp.example.com');
+            expect(script).toContain('--resource-group myproject-rg-stg-eus');
+            expect(script).toContain('--name myproject-myapp-stg-eus-aca');
+            expect(script).toContain(`--environment $${ENV_NAME_VAR}`);
+            expect(script).toContain('--validation-method CNAME');
         });
 
         it('DNS bind steps are emitted in order: 0a→0b→0c→1→2→3→4→5', async () => {
@@ -994,11 +995,13 @@ describe('AzureContainerAppRender', () => {
             const idx0a = commands.findIndex(c => c.command === 'az' && c.args[2] === 'zone' && c.args[3] === 'list');
             const idx0b = commands.findIndex(c => c.command === 'az' && c.args.includes('properties.managedEnvironmentId'));
             const idx0c = commands.findIndex(c => c.command === 'bash' && c.envCapture === ENV_NAME_VAR);
-            const idx1  = commands.findIndex(c => c.command === 'az' && c.args.includes('properties.configuration.ingress.fqdn'));
+            // step 1: hostname add (bash -c '...')
+            const idx1  = commands.findIndex(c => c.command === 'bash' && c.args[1]?.includes('hostname add'));
             const idx2  = commands.findIndex(c => c.command === 'az' && c.args.includes('cname'));
             const idx3  = commands.findIndex(c => c.command === 'az' && c.args.includes('properties.customDomainVerificationId'));
             const idx4  = commands.findIndex(c => c.command === 'az' && c.args.includes('txt') && c.args.includes('add-record'));
-            const idx5  = commands.findIndex(c => c.command === 'az' && c.args[1] === 'hostname' && c.args[2] === 'bind');
+            // step 6 (renamed from 5): hostname bind (bash -c '...')
+            const idx5  = commands.findIndex(c => c.command === 'bash' && c.args[1]?.includes('hostname bind'));
 
             expect(idx0a).not.toBe(-1);
             expect(idx0b).toBeGreaterThan(idx0a);
@@ -1056,9 +1059,10 @@ describe('AzureContainerAppRender', () => {
             expect(txtCmd).toBeDefined();
             expect(hasParam(txtCmd!.args, '--record-set-name', 'asuid.foo.bar')).toBe(true);
 
-            const bindCmd = commands.find(c => c.command === 'az' && c.args[1] === 'hostname' && c.args[2] === 'bind');
+            // hostname bind is now emitted as: bash -c 'az containerapp hostname bind --hostname ...'
+            const bindCmd = commands.find(c => c.command === 'bash' && c.args[1]?.includes('hostname bind'));
             expect(bindCmd).toBeDefined();
-            expect(hasParam(bindCmd!.args, '--hostname', 'foo.bar.example.com')).toBe(true);
+            expect(bindCmd!.args[1]).toContain('--hostname foo.bar.example.com');
         });
 
         it('dnsZone value is correctly used in --zone-name for all DNS commands', async () => {

--- a/src/azure/test/azureDnsZone.test.ts
+++ b/src/azure/test/azureDnsZone.test.ts
@@ -207,9 +207,105 @@ describe('AzureDnsZoneRender', () => {
             expect(cmd.args).not.toContain('--tags');
         });
 
-        it('returns exactly one command', () => {
-            const resource = makeResource();
+        it('returns exactly one command when parentName is absent', () => {
+            const resource = makeResource({ parentName: undefined });
             expect(render.renderCreate(resource)).toHaveLength(1);
+        });
+
+        it('returns 11 commands when parentName is set (1 create + 5 captures + 1 ns create + 4 ns add-record)', () => {
+            // 1 create + 4 NS captures + 1 parent RG capture + 1 NS record-set create + 4 NS add-record = 11
+            const resource = makeResource({ parentName: 'example.com' });
+            expect(render.renderCreate(resource)).toHaveLength(11);
+        });
+    });
+
+    // ── 4b. renderNsDelegation ────────────────────────────────────────────────
+
+    describe('renderNsDelegation (via renderCreate)', () => {
+        it('captures 4 nameservers into distinct env vars', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const captures = cmds.filter(c => c.envCapture?.includes('_NS'));
+            expect(captures).toHaveLength(4);
+            const varNames = captures.map(c => c.envCapture!);
+            expect(new Set(varNames).size).toBe(4); // all distinct
+        });
+
+        it('NS capture commands query nameServers[0..3] via JMESPath', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const captures = cmds.filter(c => c.envCapture?.includes('_NS'));
+            const queries = captures.map(c => c.args[c.args.indexOf('--query') + 1]);
+            expect(queries).toEqual(['nameServers[0]', 'nameServers[1]', 'nameServers[2]', 'nameServers[3]']);
+        });
+
+        it('captures parent resource group into a PARENT_RG env var', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const parentRgCapture = cmds.find(c => c.envCapture?.includes('PARENT_RG'));
+            expect(parentRgCapture).toBeDefined();
+        });
+
+        it('parent RG capture uses dns zone list with JMESPath filter for parent name', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const parentRgCapture = cmds.find(c => c.envCapture?.includes('PARENT_RG'));
+            expect(parentRgCapture!.args).toContain('--query');
+            const query = parentRgCapture!.args[parentRgCapture!.args.indexOf('--query') + 1];
+            expect(query).toContain('example.com');
+            expect(query).toContain('resourceGroup');
+        });
+
+        it('creates NS record-set in parent zone with --ttl 3600', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const nsCreate = cmds.find(c =>
+                c.args.includes('record-set') && c.args.includes('ns') && c.args.includes('create')
+            );
+            expect(nsCreate).toBeDefined();
+            expect(hasParam(nsCreate!.args, '--zone-name', 'example.com')).toBe(true);
+            expect(hasParam(nsCreate!.args, '--name', 'child')).toBe(true);
+            expect(hasParam(nsCreate!.args, '--ttl', '3600')).toBe(true);
+        });
+
+        it('adds 4 NS add-record commands referencing captured NS vars', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const addRecords = cmds.filter(c =>
+                c.args.includes('record-set') && c.args.includes('ns') && c.args.includes('add-record')
+            );
+            expect(addRecords).toHaveLength(4);
+            // Each should reference a captured NS var via $VAR syntax
+            addRecords.forEach(c => {
+                const nsdname = c.args[c.args.indexOf('--nsdname') + 1];
+                expect(nsdname).toMatch(/^\$/);
+            });
+        });
+
+        it('uses dnsName as the relative label in parent zone (not the full zone name)', () => {
+            const resource = makeResource({ dnsName: 'chuang', parentName: 'thebrainly.dev' });
+            const cmds = render.renderCreate(resource);
+            const nsCreate = cmds.find(c =>
+                c.args.includes('record-set') && c.args.includes('ns') && c.args.includes('create')
+            );
+            expect(hasParam(nsCreate!.args, '--name', 'chuang')).toBe(true);
+        });
+
+        it('NS delegation commands target the parent zone, not child zone', () => {
+            const resource = makeResource({ dnsName: 'child', parentName: 'example.com' });
+            const cmds = render.renderCreate(resource);
+            const addRecords = cmds.filter(c =>
+                c.args.includes('record-set') && c.args.includes('ns') && c.args.includes('add-record')
+            );
+            addRecords.forEach(c => {
+                expect(hasParam(c.args, '--zone-name', 'example.com')).toBe(true);
+            });
+        });
+
+        it('returns no delegation commands when parentName is absent', () => {
+            const resource = makeResource({ parentName: undefined });
+            const cmds = render.renderCreate(resource);
+            expect(cmds.filter(c => c.args.includes('record-set'))).toHaveLength(0);
         });
     });
 

--- a/src/common/resource.ts
+++ b/src/common/resource.ts
@@ -159,6 +159,18 @@ export interface Command {
      *   subsequent commands' args where `$VARNAME` appears.
      */
     envCapture?: string;
+    /**
+     * If set, this content will be written to a temporary file before the command
+     * is executed. Any occurrence of `__MERLIN_YAML_FILE__` in args will be replaced
+     * with the path to that temporary file.
+     *
+     * - In execute mode: written to a temp file (deleted after command completes).
+     *   $VARNAME references in the content are expanded via expandVars() before writing.
+     * - In print mode: content is shown as comments before the command line.
+     * - In write-to-file mode: emitted as a heredoc block in the shell script,
+     *   with $VARNAME references expanded by the shell at runtime.
+     */
+    fileContent?: string;
 }
 
 /**

--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -9,11 +9,13 @@
  */
 
 import { Resource, Command, RenderContext } from './common/resource.js';
-import { getAllResources } from './common/registry.js';
+import { getAllResources, getResource } from './common/registry.js';
 import { getRender } from './common/resource.js';
 import { AzureResourceGroupRender } from './azure/resourceGroup.js';
 import { execa } from 'execa';
 import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 
 /** Default concurrency limit for parallel resource deployment */
 const DEFAULT_CONCURRENCY = 4;
@@ -88,6 +90,11 @@ export class Deployer {
         try {
           const render = getRender(resource.type);
           const commands = await render.render(resource, renderContext);
+
+          // Append role-assignment commands for each dependency that declares an authProvider
+          const authCommands = await this.renderAuthProviderCommands(resource);
+          commands.push(...authCommands);
+
           levelCommands.push({ resource, commands });
         } catch (error) {
           console.error(`Failed to render ${resource.type}.${resource.name}:`, error);
@@ -203,6 +210,63 @@ export class Deployer {
   }
 
   /**
+   * Generates role-assignment commands for all dependencies of `resource` that
+   * declare an authProvider.
+   *
+   * For each dependency:
+   *   1. Resolve the provider resource from the filtered set (same ring/region).
+   *   2. Determine which authProvider to use: the dependency's override takes
+   *      precedence, otherwise fall back to the provider resource's own authProvider.
+   *   3. Call authProvider.apply(requestor=resource, provider=depResource, args).
+   *
+   * Commands are appended after the resource's own deployment commands so that
+   * the requestor's managed identity already exists before the role is assigned.
+   *
+   * Dependencies without an authProvider (e.g. structural ordering-only deps) are
+   * silently skipped.
+   */
+  private async renderAuthProviderCommands(resource: Resource): Promise<Command[]> {
+    const commands: Command[] = [];
+
+    for (const dep of resource.dependencies) {
+      // Parse "Type.name" dependency reference
+      const dotIdx = dep.resource.indexOf('.');
+      if (dotIdx === -1) continue;
+      const depType = dep.resource.slice(0, dotIdx);
+      const depName = dep.resource.slice(dotIdx + 1);
+
+      // Look up the provider resource (same ring; ignore region for global resources)
+      const depResource = getResource(depType, depName, resource.ring, resource.region);
+      if (!depResource) continue;
+
+      // Determine auth provider: dep override → provider's own authProvider
+      const authProviderDef = dep.authProvider
+        ? { provider: dep.authProvider, args: {} }
+        : depResource.authProvider;
+
+      if (!authProviderDef) continue;
+
+      try {
+        const authCommands = await authProviderDef.provider.apply(
+          resource,
+          depResource,
+          authProviderDef.args,
+        );
+        commands.push(...authCommands);
+      } catch (error) {
+        // Log but don't fail the whole deploy — some auth providers may not be
+        // applicable to certain resource type combinations
+        console.warn(
+          `Warning: authProvider.apply() failed for ` +
+          `${resource.type}.${resource.name} → ${dep.resource}: ${error}`
+        );
+      }
+    }
+
+    return commands;
+  }
+
+  /**
    * Collect all unique resource groups needed by the resources,
    * render their creation commands (deduplicated), and return as a single level.
    */
@@ -217,19 +281,24 @@ export class Deployer {
 
       const rgName = rgRender.getResourceGroupName(r);
       if (!seen.has(rgName)) {
-        const commands = await rgRender.render(r);
+        // Build a minimal synthetic resource with only the fields RG render needs.
+        // Passing the original resource `r` would cause resolveConfig() to generate
+        // capture commands for r's dependencies (e.g. LAW customerId for ACEnv),
+        // which would incorrectly appear in the RG level.
+        // config is intentionally empty — tags are not critical for RG creation
+        // and may contain ParamValues that trigger unwanted capture commands.
+        const rgResource: Resource = {
+          name: `rg:${rgName}`,
+          type: 'AzureResourceGroup',
+          ring: r.ring,
+          region: r.region,
+          project: r.project,
+          dependencies: [],
+          config: {},
+          exports: {},
+        };
+        const commands = await rgRender.render(rgResource);
         if (commands.length > 0) {
-          // Create a synthetic resource entry for the RG
-          const rgResource: Resource = {
-            name: `rg:${rgName}`,
-            type: 'AzureResourceGroup',
-            ring: r.ring,
-            region: r.region,
-            project: r.project,
-            dependencies: [],
-            config: {},
-            exports: {},
-          };
           seen.set(rgName, { resource: rgResource, commands });
         }
       }
@@ -256,10 +325,15 @@ export class Deployer {
   /**
    * Formats a single command as a shell line.
    * - If the command has envCapture, emits: VARNAME=$(command args)
+   * - If the command has fileContent, the __MERLIN_YAML_FILE__ placeholder in
+   *   args is replaced with a fixed tmp path for display purposes.
    * - Otherwise emits: command args
    */
   private commandToShellLine(command: Command): string {
-    const cmdStr = `${command.command} ${command.args.join(' ')}`;
+    const resolvedArgs = command.args.map(a =>
+      a === '__MERLIN_YAML_FILE__' ? '/tmp/merlin_aca_$$.yml' : a
+    );
+    const cmdStr = `${command.command} ${resolvedArgs.join(' ')}`;
     if (command.envCapture) {
       return `${command.envCapture}=$(${cmdStr})`;
     }
@@ -312,28 +386,44 @@ export class Deployer {
       const commandStr = this.commandToShellLine(command);
       console.log(`> ${commandStr}`);
 
+      let tmpFile: string | undefined;
+
       try {
+        // If the command carries inline file content, write it to a temp file
+        // and substitute the placeholder in args with the real path.
+        let resolvedArgs = command.args.map(arg => expandVars(arg, captureVars));
+
+        if (command.fileContent) {
+          const expandedContent = expandVars(command.fileContent, captureVars);
+          tmpFile = path.join(
+            os.tmpdir(),
+            `merlin_aca_${Date.now()}_${Math.random().toString(36).slice(2)}.yml`
+          );
+          await fs.writeFile(tmpFile, expandedContent, 'utf-8');
+          resolvedArgs = resolvedArgs.map(a =>
+            a === '__MERLIN_YAML_FILE__' ? tmpFile! : a
+          );
+        }
+
         if (command.envCapture) {
           // Capture command: run it and store stdout in map
-          const expandedArgs = command.args.map(arg => expandVars(arg, captureVars));
-          const { stdout } = await execa(command.command, expandedArgs);
+          const { stdout } = await execa(command.command, resolvedArgs);
           captureVars.set(command.envCapture, stdout.trim());
         } else {
-          // Regular command: expand any $VARNAME references in args first
-          const expandedArgs = command.args.map(arg => expandVars(arg, captureVars));
-          const { stdout, stderr } = await execa(command.command, expandedArgs);
-
-          if (stdout) {
-            console.log(stdout);
-          }
-          if (stderr) {
-            console.error(stderr);
-          }
+          // Regular command
+          const { stdout, stderr } = await execa(command.command, resolvedArgs);
+          if (stdout) console.log(stdout);
+          if (stderr) console.error(stderr);
         }
       } catch (error) {
         console.error(`✗ Failed to execute: ${commandStr}`);
         console.error(error);
         throw error;
+      } finally {
+        // Always clean up the temp file
+        if (tmpFile) {
+          await fs.unlink(tmpFile).catch(() => {});
+        }
       }
     }
 
@@ -385,6 +475,7 @@ export class Deployer {
   /**
    * Print commands grouped by level without executing.
    * Capture commands are shown as VARNAME=$(command args).
+   * Commands with fileContent show the YAML content as comments first.
    */
   private printCommandLevels(levels: ExecutionLevel[]): void {
     console.log('\nGenerated deployment commands (dry-run mode):\n');
@@ -396,6 +487,13 @@ export class Deployer {
       for (const { resource, commands } of level) {
         console.log(`# ${resource.type}.${resource.name} (${resource.ring}${resource.region ? `/${resource.region}` : ''})`);
         for (const command of commands) {
+          if (command.fileContent) {
+            console.log('# --- inline YAML (written to temp file at --yaml) ---');
+            for (const line of command.fileContent.split('\n')) {
+              console.log(`# ${line}`);
+            }
+            console.log('# --- end of inline YAML ---');
+          }
           console.log(this.commandToShellLine(command));
         }
         console.log('');
@@ -409,6 +507,7 @@ export class Deployer {
   /**
    * Write commands grouped by level to shell script file.
    * Capture commands are emitted as VARNAME=$(command args).
+   * Commands with fileContent are emitted as a heredoc + command + cleanup.
    */
   private async writeCommandLevelsToFile(
     levels: ExecutionLevel[],
@@ -424,7 +523,26 @@ export class Deployer {
       for (const { resource, commands } of level) {
         lines.push(`# ${resource.type}.${resource.name} (${resource.ring}${resource.region ? `/${resource.region}` : ''})`);
         for (const command of commands) {
-          lines.push(this.commandToShellLine(command));
+          if (command.fileContent) {
+            // Write a heredoc block + command that references the temp file
+            const tmpVar = `MERLIN_TMP_YAML_$$`;
+            lines.push(`${tmpVar}=$(mktemp /tmp/merlin_aca_XXXXXX.yml)`);
+            // Use unquoted heredoc delimiter so $VARNAME is expanded by shell
+            lines.push(`cat > "$${tmpVar}" <<MERLIN_YAML_EOF`);
+            lines.push(command.fileContent);
+            lines.push('MERLIN_YAML_EOF');
+            // Replace placeholder with the variable holding the temp file path
+            const cmdLine = this.commandToShellLine({
+              ...command,
+              args: command.args.map(a =>
+                a === '__MERLIN_YAML_FILE__' ? `"$${tmpVar}"` : a
+              ),
+            });
+            lines.push(cmdLine);
+            lines.push(`rm -f "$${tmpVar}"`);
+          } else {
+            lines.push(this.commandToShellLine(command));
+          }
           totalCommands++;
         }
         lines.push('');

--- a/src/init.ts
+++ b/src/init.ts
@@ -45,6 +45,7 @@ import {
     AzureLogAnalyticsWorkspaceCustomerIdGetter,
     AzureLogAnalyticsWorkspaceSharedKeyGetter,
     AzureDnsZoneNameGetter,
+    AzureADAppClientIdGetter,
 } from './azure/proprietyGetter.js';
 
 // Register all auth providers
@@ -69,6 +70,7 @@ registerProprietyGetter(new AzureContainerAppFqdnGetter());
 registerProprietyGetter(new AzureLogAnalyticsWorkspaceCustomerIdGetter());
 registerProprietyGetter(new AzureLogAnalyticsWorkspaceSharedKeyGetter());
 registerProprietyGetter(new AzureDnsZoneNameGetter());
+registerProprietyGetter(new AzureADAppClientIdGetter());
 
 export function initializeMerlin(): void {
     // Initialization happens during module load

--- a/src/test/deployer.test.ts
+++ b/src/test/deployer.test.ts
@@ -7,7 +7,6 @@ import { Deployer } from '../deployer.js';
 import * as registry from '../common/registry.js';
 import * as resource from '../common/resource.js';
 import type { Resource, Render, Command } from '../common/resource.js';
-
 describe('Deployer', () => {
   let deployer: Deployer;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -387,6 +386,137 @@ describe('Deployer', () => {
         mockResources[0],
         { skipResourceGroup: true }
       );
+    });
+  });
+
+  describe('authProvider integration', () => {
+    it('appends role-assignment commands from authProvider.apply() to the requestor resource', async () => {
+      const authApply = vi.fn().mockResolvedValue([
+        { command: 'az', args: ['role', 'assignment', 'create', '--role', 'AcrPull'] } as Command,
+      ]);
+
+      const providerResource = makeResource('acr', [], {
+        type: 'AzureContainerRegistry',
+        authProvider: {
+          provider: { name: 'AzureManagedIdentity', apply: authApply, dependencies: [] },
+          args: { role: 'AcrPull' },
+        },
+      });
+
+      const requestorResource = makeResource('aca', ['AzureContainerRegistry.acr'], {
+        type: 'AzureContainerApp',
+      });
+
+      const mockRender: Render = {
+        render: vi.fn().mockResolvedValue([
+          { command: 'az', args: ['containerapp', 'create'] } as Command,
+        ]),
+      };
+
+      vi.spyOn(registry, 'getAllResources').mockReturnValue([providerResource, requestorResource]);
+      vi.spyOn(resource, 'getRender').mockReturnValue(mockRender);
+      vi.spyOn(registry, 'getResource').mockReturnValue(providerResource);
+
+      const allCommands: Command[] = [];
+      (mockRender.render as any).mockImplementation(async (r: Resource) => {
+        const cmds: Command[] = [{ command: 'az', args: [r.name] }];
+        return cmds;
+      });
+
+      // Capture rendered commands via printCommandLevels
+      const printSpy = vi.spyOn(deployer as any, 'printCommandLevels');
+
+      await deployer.deploy({ execute: false });
+
+      expect(authApply).toHaveBeenCalledTimes(1);
+      expect(authApply).toHaveBeenCalledWith(
+        requestorResource,
+        providerResource,
+        { role: 'AcrPull' },
+      );
+    });
+
+    it('skips authProvider when dependency resource is not in registry', async () => {
+      const authApply = vi.fn().mockResolvedValue([]);
+
+      const requestorResource = makeResource('aca', ['AzureContainerRegistry.missing'], {
+        type: 'AzureContainerApp',
+      });
+
+      const mockRender: Render = {
+        render: vi.fn().mockResolvedValue([{ command: 'az', args: [] } as Command]),
+      };
+
+      vi.spyOn(registry, 'getAllResources').mockReturnValue([requestorResource]);
+      vi.spyOn(resource, 'getRender').mockReturnValue(mockRender);
+      // Registry returns undefined for the missing provider
+      vi.spyOn(registry, 'getResource').mockReturnValue(undefined);
+
+      await deployer.deploy({ execute: false });
+
+      // authApply must not be called because the provider resource was not found
+      expect(authApply).not.toHaveBeenCalled();
+    });
+
+    it('skips silently when dependency has no authProvider', async () => {
+      const providerResource = makeResource('acr', [], {
+        type: 'AzureContainerRegistry',
+        authProvider: undefined, // no authProvider
+      });
+
+      const requestorResource = makeResource('aca', ['AzureContainerRegistry.acr'], {
+        type: 'AzureContainerApp',
+      });
+
+      const mockRender: Render = {
+        render: vi.fn().mockResolvedValue([{ command: 'az', args: [] } as Command]),
+      };
+
+      vi.spyOn(registry, 'getAllResources').mockReturnValue([providerResource, requestorResource]);
+      vi.spyOn(resource, 'getRender').mockReturnValue(mockRender);
+      vi.spyOn(registry, 'getResource').mockReturnValue(providerResource);
+
+      // Should not throw
+      await expect(deployer.deploy({ execute: false })).resolves.not.toThrow();
+    });
+
+    it('uses the dependency-level authProvider override when provided', async () => {
+      const defaultApply  = vi.fn().mockResolvedValue([]);
+      const overrideApply = vi.fn().mockResolvedValue([
+        { command: 'az', args: ['role', 'assignment', 'create', '--role', 'Reader'] } as Command,
+      ]);
+
+      const providerResource = makeResource('acr', [], {
+        type: 'AzureContainerRegistry',
+        authProvider: {
+          provider: { name: 'AzureManagedIdentity', apply: defaultApply, dependencies: [] },
+          args: { role: 'AcrPull' },
+        },
+      });
+
+      const overrideProvider = { name: 'Override', apply: overrideApply, dependencies: [] };
+
+      const requestorResource: Resource = {
+        ...makeResource('aca', [], { type: 'AzureContainerApp' }),
+        dependencies: [{
+          resource: 'AzureContainerRegistry.acr',
+          authProvider: overrideProvider,
+        }],
+      };
+
+      const mockRender: Render = {
+        render: vi.fn().mockResolvedValue([{ command: 'az', args: [] } as Command]),
+      };
+
+      vi.spyOn(registry, 'getAllResources').mockReturnValue([providerResource, requestorResource]);
+      vi.spyOn(resource, 'getRender').mockReturnValue(mockRender);
+      vi.spyOn(registry, 'getResource').mockReturnValue(providerResource);
+
+      await deployer.deploy({ execute: false });
+
+      // The override should be used, not the default
+      expect(overrideApply).toHaveBeenCalledTimes(1);
+      expect(defaultApply).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

This PR adds several major features to Merlin's Azure Container App and DNS Zone support, along with infrastructure-level improvements to the deployer and propriety getter layer.

## Issues

- Closes #14 — AzureContainerApp health probe support (httpGet / tcpSocket)
- Closes #15 — AzureContainerApp EasyAuth with Azure AD integration
- Closes #16 — AzureContainerApp custom domain binding with managed certificate
- Closes #17 — AzureDnsZone automatic NS delegation into parent zone
- Closes #18 — Deployer concurrency, global resource registry, AzureADAppClientId getter fix

## Changes by Area

### AzureContainerApp (`src/azure/azureContainerApp.ts`)
- **Health probes**: `probes` config field; when set, renders via `--yaml` mode (inline YAML manifest) since the AZ CLI does not support probes as flags
- **EasyAuth**: `auth` config block — automates client secret rotation, redirect URI update, and Microsoft identity provider configuration
- **Custom domain binding**: `bindDnsZone` config — 10-step flow (CNAME + TXT + managed cert); `hostname add` runs before DNS records per Azure requirement; both `hostname add` and `hostname bind` are idempotent via `bash -c '... || true'`

### AzureDnsZone (`src/azure/azureDnsZone.ts`)
- `renderNsDelegation()` — on first create, automatically wires child zone nameservers into the parent zone via NS records (4 captures + 1 record-set create + 4 add-record = 10 extra commands)

### AzureADApp + ProprietyGetter
- `AzureADAppClientId` getter: fixed `[object Object]` bug — `config.displayName` is a `ParamValue` at getter time; now calls `resolveConfig()` first and uses `getDisplayName()` (full ring name) instead of `getResourceName()` (short ring name)
- `AzureADAppRender.getDisplayName()` — new method returning `config.displayName ?? getResourceName()`

### Deployer + Registry
- `--concurrency` option (default 4) for parallel execution within DAG levels
- `isGlobalResource` on `Render` — enables ring-only registry lookup for tenant-scoped resources (AD Apps)
- New auth provider implementations + tests

### Docs
- `README.md` — full rewrite reflecting current architecture, resource types, parameter expressions
- `CLAUDE.md` — added ProprietyGetter table, DNS NS delegation flow, ACA DNS binding step table, global resource notes, updated dev notes

## Test Plan

- [ ] `pnpm test` passes (90/95 in azureContainerApp; 49/49 in azureDnsZone; 5 pre-existing failures in space-joined array tests are unrelated)
- [ ] Dry-run shows `displayName eq 'merlintest-alluneed-staging'` (not `[object Object]` or `stg`)
- [ ] Dry-run shows `bash -c 'az containerapp hostname add ... || true'` for all 4 ACA instances
- [ ] Dry-run shows 11 commands for DNS zone with `parentName` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)