### PR TITLE
feat: simplify CLI — merlin init, short names, deploy safety, rename project to brainly

### DIFF
--- a/alluneed-k8s-resource/alluneeddeployment.yml
+++ b/alluneed-k8s-resource/alluneeddeployment.yml
@@ -1,6 +1,6 @@
 name: alluneed
 type: KubernetesDeployment
-project: merlin
+project: alluneed
 ring:
   - test
   - staging
@@ -23,7 +23,7 @@ defaultConfig:
 
   containers:
     - name: alluneed
-      image: merlinsharedstgkrcacr.azurecr.io/alluneed:latest
+      image: brainlysharedstgkrcacr.azurecr.io/alluneed:latest
       imagePullPolicy: IfNotPresent
       port: 8000
       cpuRequest: "1000m"

--- a/alluneed-k8s-resource/alluneedingress.yml
+++ b/alluneed-k8s-resource/alluneedingress.yml
@@ -1,6 +1,6 @@
 name: alluneed
 type: KubernetesIngress
-project: merlin
+project: alluneed
 ring:
   - test
   - staging

--- a/alluneed-k8s-resource/alluneedsecretprovider.yml
+++ b/alluneed-k8s-resource/alluneedsecretprovider.yml
@@ -1,6 +1,6 @@
 name: alluneed-secret-provider
 type: KubernetesManifest
-project: merlin
+project: alluneed
 ring:
   - test
   - staging

--- a/alluneed-k8s-resource/alluneedsvc.yml
+++ b/alluneed-k8s-resource/alluneedsvc.yml
@@ -1,6 +1,6 @@
 name: alluneed
 type: KubernetesService
-project: merlin
+project: alluneed
 ring:
   - test
   - staging

--- a/alluneed-k8s-resource/alluneedworkloadsa.yml
+++ b/alluneed-k8s-resource/alluneedworkloadsa.yml
@@ -1,6 +1,6 @@
 name: alluneed-workload-sa
 type: KubernetesServiceAccount
-project: merlin
+project: alluneed
 ring:
   - test
   - staging

--- a/shared-k8s-resource/sharedkvsp.yml
+++ b/shared-k8s-resource/sharedkvsp.yml
@@ -1,6 +1,6 @@
 name: kv-workload
 type: AzureServicePrincipal
-project: merlin
+project: brainly
 ring:
   - test
   - staging
@@ -23,7 +23,7 @@ defaultConfig:
 
 specificConfig:
   - ring: test
-    displayName: merlin-kv-workload-tst
+    displayName: brainly-kv-workload-tst
     federatedCredentials:
       # Trinity namespace ServiceAccount
       - name: trinity-sa
@@ -40,17 +40,17 @@ specificConfig:
     roleAssignments:
       # Key Vault Secrets User on both regional Key Vaults
       - role: Key Vault Secrets User
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-krc/providers/Microsoft.KeyVault/vaults/merlinsharedtstkrcakv
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc/providers/Microsoft.KeyVault/vaults/brainlysharedtstkrcakv
       - role: Key Vault Secrets User
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-eas/providers/Microsoft.KeyVault/vaults/merlinsharedtsteasakv
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas/providers/Microsoft.KeyVault/vaults/brainlysharedtsteasakv
       # Storage Blob Data Contributor on both regional Storage Accounts
       - role: Storage Blob Data Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-krc/providers/Microsoft.Storage/storageAccounts/merlinsharedtstkrcabs
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc/providers/Microsoft.Storage/storageAccounts/brainlysharedtstkrcabs
       - role: Storage Blob Data Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-eas/providers/Microsoft.Storage/storageAccounts/merlinsharedtsteasabs
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas/providers/Microsoft.Storage/storageAccounts/brainlysharedtsteasabs
 
   - ring: staging
-    displayName: merlin-kv-workload-stg
+    displayName: brainly-kv-workload-stg
     federatedCredentials:
       - name: trinity-sa
         issuer: ${ KubernetesCluster.aks.oidcIssuerUrl }
@@ -63,14 +63,14 @@ specificConfig:
         subject: system:serviceaccount:alluneed:alluneed-workload-sa
     roleAssignments:
       - role: Key Vault Secrets User
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-krc/providers/Microsoft.KeyVault/vaults/merlinsharedstgkrcakv
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc/providers/Microsoft.KeyVault/vaults/brainlysharedstgkrcakv
       - role: Key Vault Secrets User
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-eas/providers/Microsoft.KeyVault/vaults/merlinsharedstgeasakv
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas/providers/Microsoft.KeyVault/vaults/brainlysharedstgeasakv
       # Storage Blob Data Contributor on both regional Storage Accounts
       - role: Storage Blob Data Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-krc/providers/Microsoft.Storage/storageAccounts/merlinsharedstgkrcabs
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc/providers/Microsoft.Storage/storageAccounts/brainlysharedstgkrcabs
       - role: Storage Blob Data Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-eas/providers/Microsoft.Storage/storageAccounts/merlinsharedstgeasabs
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas/providers/Microsoft.Storage/storageAccounts/brainlysharedstgeasabs
 
 exports:
   clientId: AzureServicePrincipalClientId

--- a/shared-resource/sharedabs.yml
+++ b/shared-resource/sharedabs.yml
@@ -1,6 +1,6 @@
 name: shared
 type: AzureBlobStorage
-project: merlin
+project: brainly
 ring:
   - test
   - staging

--- a/shared-resource/sharedacr.yml
+++ b/shared-resource/sharedacr.yml
@@ -1,6 +1,6 @@
 name: shared
 type: AzureContainerRegistry
-project: merlin
+project: brainly
 ring:
   - test
   - staging

--- a/shared-resource/sharedakv.yml
+++ b/shared-resource/sharedakv.yml
@@ -1,6 +1,6 @@
 name: shared
 type: AzureKeyVault
-project: merlin
+project: brainly
 ring:
   - test
   - staging

--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -1,6 +1,6 @@
 name: github
 type: AzureServicePrincipal
-project: merlin
+project: brainly
 ring:
   - test
   - staging
@@ -19,7 +19,7 @@ defaultConfig:
 
 specificConfig:
   - ring: test
-    displayName: merlin-github-tst
+    displayName: brainly-github-tst
     federatedCredentials:
       - name: trinity-github-nightly
         subject: repo:TheDeltaLab/trinity:environment:nightly
@@ -28,23 +28,23 @@ specificConfig:
     roleAssignments:
       # Trinity RG — koreacentral (Container Apps Contributor)
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-krc
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc
       # Trinity RG — eastasia
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-eas
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
       # Alluneed RG — koreacentral
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-krc
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc
       # Alluneed RG — eastasia
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-eas
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
       # ACR — koreacentral
       - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-krc/providers/Microsoft.ContainerRegistry/registries/merlinsharedtstkrcacr
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc/providers/Microsoft.ContainerRegistry/registries/brainlysharedtstkrcacr
       # ACR — eastasia
       - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-tst-eas/providers/Microsoft.ContainerRegistry/registries/merlinsharedtsteasacr
-      # AKS — kubectl access for merlin K8s deploys (shared RG)
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas/providers/Microsoft.ContainerRegistry/registries/brainlysharedtsteasacr
+      # AKS — kubectl access for K8s deploys (shared RG)
       - role: Azure Kubernetes Service Cluster User Role
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-krc
       - role: Azure Kubernetes Service Cluster User Role
@@ -56,7 +56,7 @@ specificConfig:
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-eas
 
   - ring: staging
-    displayName: merlin-github-stg
+    displayName: brainly-github-stg
     federatedCredentials:
       - name: trinity-github-staging
         subject: repo:TheDeltaLab/trinity:environment:staging
@@ -65,23 +65,23 @@ specificConfig:
     roleAssignments:
       # Trinity RG — koreacentral
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-krc
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc
       # Trinity RG — eastasia
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-eas
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
       # Alluneed RG — koreacentral
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-krc
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc
       # Alluneed RG — eastasia
       - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-eas
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
       # ACR — koreacentral
       - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-krc/providers/Microsoft.ContainerRegistry/registries/merlinsharedstgkrcacr
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc/providers/Microsoft.ContainerRegistry/registries/brainlysharedstgkrcacr
       # ACR — eastasia
       - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/merlin-rg-stg-eas/providers/Microsoft.ContainerRegistry/registries/merlinsharedstgeasacr
-      # AKS — kubectl access for merlin K8s deploys (shared RG)
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas/providers/Microsoft.ContainerRegistry/registries/brainlysharedstgeasacr
+      # AKS — kubectl access for K8s deploys (shared RG)
       - role: Azure Kubernetes Service Cluster User Role
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-krc
       - role: Azure Kubernetes Service Cluster User Role

--- a/shared-resource/sharedpsql.yml
+++ b/shared-resource/sharedpsql.yml
@@ -1,6 +1,6 @@
 name: shared
 type: AzurePostgreSQLFlexible
-project: merlin
+project: brainly
 ring:
   - test
   - staging

--- a/shared-resource/sharedredis.yml
+++ b/shared-resource/sharedredis.yml
@@ -1,6 +1,6 @@
 name: shared
 type: AzureRedisEnterprise
-project: merlin
+project: brainly
 ring:
   - test
   - staging

--- a/src/cli/confirm.ts
+++ b/src/cli/confirm.ts
@@ -1,0 +1,75 @@
+/**
+ * Deploy safety guards — prevents accidental deployments to
+ * all rings or to production without explicit confirmation.
+ */
+
+import { createInterface } from 'readline';
+
+export interface ConfirmDeployOptions {
+    execute: boolean;
+    ring?: string;
+    all: boolean;
+    yes: boolean;
+}
+
+/**
+ * Checks whether the deployment should proceed based on safety rules.
+ *
+ * Rules:
+ * 1. Non-execute (dry-run) → always proceed
+ * 2. Execute + no ring + no --all → reject (all-ring deploy needs explicit confirmation)
+ * 3. Execute + production + no --yes → interactive confirmation
+ * 4. Execute + production + --yes → proceed (CI mode)
+ * 5. Execute + test/staging → proceed
+ * 6. Non-TTY + production + no --yes → reject
+ */
+export async function confirmDeploy(options: ConfirmDeployOptions): Promise<boolean> {
+    // Rule 1: dry-run is always safe
+    if (!options.execute) return true;
+
+    // Rule 2: deploying to all rings requires --all
+    if (!options.ring && !options.all) {
+        console.error('⚠️  No --ring specified. This will deploy to ALL rings.');
+        console.error('   Use --all to confirm, or specify --ring <ring>.');
+        return false;
+    }
+
+    // Rule 5: test/staging proceed without confirmation
+    if (options.ring && options.ring !== 'production') return true;
+
+    // Rule 4: production with --yes skips confirmation (CI mode)
+    if (options.ring === 'production' && options.yes) return true;
+
+    // Rule 6: non-TTY without --yes is rejected
+    if (options.ring === 'production' && !process.stdin.isTTY) {
+        console.error('⚠️  Deploying to PRODUCTION requires --yes flag in non-interactive mode.');
+        return false;
+    }
+
+    // Rule 3: production requires interactive confirmation
+    if (options.ring === 'production') {
+        return promptConfirmation('⚠️  About to deploy to PRODUCTION. Type \'yes\' to confirm: ');
+    }
+
+    // --all with no ring: deploying to all rings
+    if (!options.ring && options.all) return true;
+
+    return true;
+}
+
+/**
+ * Prompts the user for a 'yes' confirmation.
+ */
+function promptConfirmation(message: string): Promise<boolean> {
+    return new Promise((resolve) => {
+        const rl = createInterface({
+            input: process.stdin,
+            output: process.stderr,
+        });
+
+        rl.question(message, (answer) => {
+            rl.close();
+            resolve(answer.trim().toLowerCase() === 'yes');
+        });
+    });
+}

--- a/src/cli/defaults.ts
+++ b/src/cli/defaults.ts
@@ -1,0 +1,37 @@
+/**
+ * CLI defaults — loads merlin.yml project config and extracts
+ * the first ring/region as CLI default values.
+ */
+
+import { loadProjectConfig } from '../compiler/projectConfig.js';
+
+export interface CLIDefaults {
+    ring?: string;
+    region?: string;
+    project?: string;
+}
+
+/**
+ * Reads merlin.yml from the given resource directory and extracts
+ * CLI-usable default values (first ring, first region, project name).
+ *
+ * Returns undefined if merlin.yml doesn't exist or can't be parsed.
+ */
+export function loadCLIDefaults(resourceDir: string): CLIDefaults | undefined {
+    const config = loadProjectConfig(resourceDir);
+    if (!config) return undefined;
+
+    const ring = Array.isArray(config.ring)
+        ? config.ring[0]
+        : config.ring;
+
+    const region = Array.isArray(config.region)
+        ? config.region[0]
+        : config.region;
+
+    return {
+        ring,
+        region,
+        project: config.project,
+    };
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,407 @@
+/**
+ * `merlin init` — project scaffolding and template generation.
+ *
+ * Generates a complete set of Merlin resource YAML files in the project's
+ * `merlin-resources/` directory, based on real-world patterns from
+ * trinity and alluneed projects.
+ */
+
+import { mkdirSync, writeFileSync, existsSync } from 'fs';
+import * as path from 'path';
+
+export type TemplateName = 'web' | 'worker' | 'api' | 'minimal';
+
+export interface InitOptions {
+    template: TemplateName;
+    withAuth: boolean;
+    dir: string;
+}
+
+interface TemplateFile {
+    filename: string;
+    description: string;
+    content: string;
+}
+
+// ── Template generators ──────────────────────────────────────────────────────
+
+function merlinYml(project: string): TemplateFile {
+    return {
+        filename: 'merlin.yml',
+        description: 'project config',
+        content: `project: ${project}
+ring:
+  - test
+  - staging
+region:
+  - koreacentral
+`,
+    };
+}
+
+function appYml(project: string, opts: { ingress: boolean; withAuth: boolean }): TemplateFile {
+    const ingressBlock = opts.ingress ? `
+  ingress:
+    subdomain: ${project}
+    dnsZone: thebrainly.dev${opts.withAuth ? `
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email"
+    dependencies:
+      - resource: KubernetesIngress.${project}-oauth2-proxy
+        isHardDependency: true` : ''}` : '';
+
+    return {
+        filename: `${project}.yml`,
+        description: 'KubernetesApp service',
+        content: `name: ${project}
+type: KubernetesApp
+
+dependencies:
+  - resource: KubernetesServiceAccount.${project}-workload-sa
+    isHardDependency: true${opts.withAuth ? `
+  - resource: AzureServicePrincipal.${project}-aad
+    isHardDependency: true` : ''}
+
+defaultConfig:
+  namespace: ${project}
+  image: brainlysharedstgkrcacr.azurecr.io/${project}:latest  # TODO: Change to your image
+  port: 3000  # TODO: Change to your port
+  serviceAccountName: ${project}-workload-sa
+  secretProvider: ${project}-secret-provider
+  envFrom:
+    - secretRef: ${project}-secrets
+  envVars:
+    - APP_ENV=\${ this.ring }${ingressBlock}
+`,
+    };
+}
+
+function workloadSaYml(project: string): TemplateFile {
+    return {
+        filename: `${project}workloadsa.yml`,
+        description: 'ServiceAccount',
+        content: `name: ${project}-workload-sa
+type: KubernetesServiceAccount
+
+dependencies:
+  - resource: KubernetesCluster.aks
+    isHardDependency: true
+  - resource: AzureServicePrincipal.kv-workload
+    isHardDependency: true
+
+defaultConfig:
+  namespace: ${project}
+  annotations:
+    azure.workload.identity/client-id: \${ AzureServicePrincipal.kv-workload.clientId }
+  labels:
+    app.kubernetes.io/part-of: ${project}
+    managed-by: merlin
+`,
+    };
+}
+
+function secretProviderYml(project: string): TemplateFile {
+    return {
+        filename: `${project}secretprovider.yml`,
+        description: 'SecretProviderClass',
+        content: `name: ${project}-secret-provider
+type: KubernetesManifest
+
+dependencies:
+  - resource: KubernetesCluster.aks
+    isHardDependency: true
+  - resource: KubernetesServiceAccount.${project}-workload-sa
+    isHardDependency: true
+  - resource: AzureServicePrincipal.kv-workload
+    isHardDependency: true
+  - resource: AzureKeyVault.shared
+    isHardDependency: true
+
+defaultConfig:
+  namespace: ${project}
+  manifest: |
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+    metadata:
+      name: ${project}-secret-provider
+    spec:
+      provider: azure
+      parameters:
+        usePodIdentity: "false"
+        useVMManagedIdentity: "false"
+        clientID: \${ AzureServicePrincipal.kv-workload.clientId }
+        keyvaultName: \${ AzureKeyVault.shared.name }
+        tenantId: "2c10b0b9-d9c1-4c81-85ee-6a2297ed77f4"  # TODO: Change to your tenant ID
+        objects: |
+          array:
+            - |
+              objectName: ${project}-example-secret
+              objectType: secret
+      secretObjects:
+        - secretName: ${project}-secrets
+          type: Opaque
+          data:
+            - objectName: ${project}-example-secret
+              key: EXAMPLE_SECRET
+`,
+    };
+}
+
+function aadYml(project: string): TemplateFile {
+    return {
+        filename: `${project}aad.yml`,
+        description: 'Azure AD App Registration',
+        content: `name: ${project}-aad
+type: AzureServicePrincipal
+region: none
+
+authProvider:
+  name: AzureEntraID
+
+dependencies:
+  - resource: AzureKeyVault.shared
+    isHardDependency: true
+
+defaultConfig:
+  displayName: ${project}-aad-\${ this.ring }
+  webRedirectUris:
+    - https://${project}.\${ this.ring }.thebrainly.dev/oauth2/callback
+  assignmentRequired: true
+  apiPermissions: oidc
+
+specificConfig:
+  - ring: test
+    clientSecretKeyVault:
+      vaultNames:
+        - brainlysharedtstkrcakv
+      secretName: ${project}-oauth2-proxy-client-secret
+    cookieSecretKeyVault:
+      vaultNames:
+        - brainlysharedtstkrcakv
+      secretName: ${project}-oauth2-proxy-cookie-secret
+  - ring: staging
+    clientSecretKeyVault:
+      vaultNames:
+        - brainlysharedstgkrcakv
+      secretName: ${project}-oauth2-proxy-client-secret
+    cookieSecretKeyVault:
+      vaultNames:
+        - brainlysharedstgkrcakv
+      secretName: ${project}-oauth2-proxy-cookie-secret
+
+exports:
+  clientId: AzureServicePrincipalClientId
+`,
+    };
+}
+
+function oauth2ProxyYml(project: string): TemplateFile {
+    return {
+        filename: `${project}oauth2proxy.yml`,
+        description: 'OAuth2 Proxy',
+        content: `name: ${project}-oauth2-proxy
+type: KubernetesApp
+
+dependencies:
+  - resource: KubernetesManifest.${project}-oauth2-proxy-secret-provider
+    isHardDependency: true
+  - resource: KubernetesServiceAccount.${project}-workload-sa
+    isHardDependency: true
+  - resource: AzureServicePrincipal.${project}-aad
+    isHardDependency: true
+
+defaultConfig:
+  namespace: ${project}
+  image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+  port: 4180
+  serviceAccountName: ${project}-workload-sa
+  secretProvider: ${project}-oauth2-proxy-secret-provider
+  resources:
+    cpuRequest: "100m"
+    memoryRequest: "128Mi"
+    cpuLimit: "200m"
+    memoryLimit: "256Mi"
+  probes:
+    liveness: false
+    startup: false
+    readiness:
+      httpGet:
+        path: /ping
+        port: 4180
+  envFrom:
+    - secretRef: ${project}-oauth2-proxy-secrets
+  envVars:
+    - OAUTH2_PROXY_PROVIDER=oidc
+    - OAUTH2_PROXY_OIDC_ISSUER_URL=https://login.microsoftonline.com/2c10b0b9-d9c1-4c81-85ee-6a2297ed77f4/v2.0
+    - OAUTH2_PROXY_CLIENT_ID=\${ AzureServicePrincipal.${project}-aad.clientId }
+    - OAUTH2_PROXY_REDIRECT_URL=https://${project}.\${ this.ring }.thebrainly.dev/oauth2/callback
+    - OAUTH2_PROXY_UPSTREAM=static://202
+    - OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:4180
+    - OAUTH2_PROXY_EMAIL_DOMAINS=*
+    - OAUTH2_PROXY_SCOPE=openid profile email
+    - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
+    - OAUTH2_PROXY_PASS_ACCESS_TOKEN=true
+  ingress:
+    subdomain: ${project}
+    dnsZone: thebrainly.dev
+    path: /oauth2
+    bindDnsZone: false
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+`,
+    };
+}
+
+function oauth2ProxySecretProviderYml(project: string): TemplateFile {
+    return {
+        filename: `${project}oauth2proxysecretprovider.yml`,
+        description: 'OAuth2 Proxy SecretProviderClass',
+        content: `name: ${project}-oauth2-proxy-secret-provider
+type: KubernetesManifest
+
+dependencies:
+  - resource: KubernetesCluster.aks
+    isHardDependency: true
+  - resource: KubernetesServiceAccount.${project}-workload-sa
+    isHardDependency: true
+  - resource: AzureServicePrincipal.kv-workload
+    isHardDependency: true
+  - resource: AzureKeyVault.shared
+    isHardDependency: true
+
+defaultConfig:
+  namespace: ${project}
+  manifest: |
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+    metadata:
+      name: ${project}-oauth2-proxy-secret-provider
+    spec:
+      provider: azure
+      parameters:
+        usePodIdentity: "false"
+        useVMManagedIdentity: "false"
+        clientID: \${ AzureServicePrincipal.kv-workload.clientId }
+        keyvaultName: \${ AzureKeyVault.shared.name }
+        tenantId: "2c10b0b9-d9c1-4c81-85ee-6a2297ed77f4"  # TODO: Change to your tenant ID
+        objects: |
+          array:
+            - |
+              objectName: ${project}-oauth2-proxy-client-secret
+              objectType: secret
+            - |
+              objectName: ${project}-oauth2-proxy-cookie-secret
+              objectType: secret
+      secretObjects:
+        - secretName: ${project}-oauth2-proxy-secrets
+          type: Opaque
+          data:
+            - objectName: ${project}-oauth2-proxy-client-secret
+              key: OAUTH2_PROXY_CLIENT_SECRET
+            - objectName: ${project}-oauth2-proxy-cookie-secret
+              key: OAUTH2_PROXY_COOKIE_SECRET
+`,
+    };
+}
+
+// ── Template set builders ────────────────────────────────────────────────────
+
+function buildTemplateFiles(project: string, options: InitOptions): TemplateFile[] {
+    const files: TemplateFile[] = [merlinYml(project)];
+
+    switch (options.template) {
+        case 'minimal':
+            files.push(appYml(project, { ingress: false, withAuth: false }));
+            break;
+
+        case 'worker':
+            files.push(
+                appYml(project, { ingress: false, withAuth: false }),
+                workloadSaYml(project),
+                secretProviderYml(project),
+            );
+            break;
+
+        case 'api':
+            files.push(
+                appYml(project, { ingress: true, withAuth: false }),
+                workloadSaYml(project),
+                secretProviderYml(project),
+            );
+            break;
+
+        case 'web':
+        default:
+            if (options.withAuth) {
+                files.push(
+                    appYml(project, { ingress: true, withAuth: true }),
+                    workloadSaYml(project),
+                    secretProviderYml(project),
+                    aadYml(project),
+                    oauth2ProxyYml(project),
+                    oauth2ProxySecretProviderYml(project),
+                );
+            } else {
+                files.push(
+                    appYml(project, { ingress: true, withAuth: false }),
+                    workloadSaYml(project),
+                    secretProviderYml(project),
+                );
+            }
+            break;
+    }
+
+    return files;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Runs the init command — generates template files in the target directory.
+ */
+export async function runInit(projectName: string, options: InitOptions): Promise<void> {
+    const outputDir = path.resolve(process.cwd(), options.dir);
+
+    // Check if merlin.yml already exists
+    if (existsSync(path.join(outputDir, 'merlin.yml'))) {
+        console.log(`✅ merlin.yml already exists in ${options.dir}`);
+        console.log('   To regenerate, delete the existing files first.');
+        return;
+    }
+
+    // Build template files
+    const files = buildTemplateFiles(projectName, options);
+
+    // Create output directory
+    mkdirSync(outputDir, { recursive: true });
+
+    // Write all files
+    for (const file of files) {
+        const filePath = path.join(outputDir, file.filename);
+        if (existsSync(filePath)) {
+            console.log(`   ⏭️  ${file.filename} (already exists, skipped)`);
+            continue;
+        }
+        writeFileSync(filePath, file.content, 'utf-8');
+    }
+
+    // Print summary
+    console.log(`\n✅ Created ${options.dir}/ with ${files.length} files:`);
+    for (const file of files) {
+        console.log(`   - ${file.filename} (${file.description})`);
+    }
+
+    console.log(`\n📝 Next steps:`);
+    console.log(`   1. Edit ${projectName}.yml — set your container image and port`);
+    console.log(`   2. Edit ${projectName}secretprovider.yml — configure Key Vault secrets`);
+    if (options.withAuth) {
+        console.log(`   3. Edit ${projectName}aad.yml — verify Azure AD tenant and redirect URIs`);
+    }
+    console.log(`   ${options.withAuth ? '4' : '3'}. merlin compile           # verify resources compile`);
+    console.log(`   ${options.withAuth ? '5' : '4'}. merlin deploy            # dry-run (preview commands)`);
+    console.log(`   ${options.withAuth ? '6' : '5'}. merlin deploy --execute  # deploy to test/koreacentral`);
+    console.log('');
+}

--- a/src/common/compiler.ts
+++ b/src/common/compiler.ts
@@ -18,6 +18,17 @@ import {
     ExpandedResource,
     GeneratedFile
 } from '../compiler/types.js';
+
+/**
+ * Options for the list command (extends compile options with filters)
+ */
+export interface ListOptions {
+    inputPath: string;
+    inputPaths?: string[];
+    noShared?: boolean;
+    ring?: string;
+    region?: string;
+}
 import { initializeOutputDirectory, checkPnpmAvailable } from '../compiler/initializer.js';
 import { computeYAMLHash, checkCache, writeCacheFile, invalidateCache } from '../compiler/cache.js';
 import { loadProjectConfig, applyProjectDefaults, ProjectConfig } from '../compiler/projectConfig.js';
@@ -155,6 +166,54 @@ export class Compiler {
      */
     async watch(options: CompilerOptions): Promise<void> {
         throw new Error('Watch mode not yet implemented');
+    }
+
+    /**
+     * Lists all resources after expansion (no code generation or build).
+     * Reuses compile pipeline steps 1-5, then filters by ring/region.
+     */
+    async list(options: ListOptions): Promise<ExpandedResource[]> {
+        // 1. Discover YAML files
+        const sharedPaths = options.noShared ? [] : await this.getSharedResourcePaths();
+        const allInputPaths = [options.inputPath, ...(options.inputPaths ?? []), ...sharedPaths];
+        const yamlFileArrays = await Promise.all(allInputPaths.map(p => this.discoverYAMLFiles(p)));
+        const yamlFiles = [...new Set(yamlFileArrays.flat())];
+        if (yamlFiles.length === 0) return [];
+
+        // 2. Parse
+        const errors: CompilationError[] = [];
+        const parsedFiles = await this.parseAllFiles(yamlFiles, errors);
+        if (parsedFiles.length === 0) return [];
+
+        // 2.5. Project defaults
+        const inputDirs = this.getUniqueDirs(parsedFiles);
+        const projectConfigMap = this.discoverProjectConfigs(inputDirs);
+        const filesWithDefaults = this.applyProjectDefaultsToAll(parsedFiles, projectConfigMap);
+
+        // 3. Validate
+        const warnings: CompilationError[] = [];
+        const validatedResources = this.validateAllFiles(filesWithDefaults, errors, warnings);
+        if (errors.length > 0) {
+            throw new Error(errors.map(e => e.message).join('\n'));
+        }
+
+        // 4. Expand composite types (KubernetesApp → Deployment + Service + Ingress)
+        const expandedYAMLs = this.expandCompositeResources(validatedResources);
+
+        // 5. Transform (ring × region cartesian product)
+        const expandedResources = this.transformResources(expandedYAMLs);
+        const merged = this.mergeBySource(expandedResources);
+        let allResources = merged.flatMap(m => m.resources);
+
+        // 6. Filter by ring/region
+        if (options.ring) {
+            allResources = allResources.filter(r => r.ring === options.ring);
+        }
+        if (options.region) {
+            allResources = allResources.filter(r => r.region === options.region);
+        }
+
+        return allResources;
     }
 
     /**

--- a/src/common/resolveNames.ts
+++ b/src/common/resolveNames.ts
@@ -1,0 +1,48 @@
+/**
+ * Ring/Region short name ↔ full name resolution.
+ *
+ * Allows CLI users to type `--ring stg` or `--region krc` instead of
+ * the full `--ring staging` / `--region koreacentral`.
+ *
+ * Full names pass through unchanged; unknown values pass through as-is
+ * (downstream validation will catch invalid names).
+ */
+
+import { RING_SHORT_NAME_MAP, REGION_SHORT_NAME_MAP, Ring, Region } from './resource.js';
+
+// Build reverse maps: short → full
+export const RING_LONG_NAME_MAP: Record<string, Ring> = Object.fromEntries(
+    Object.entries(RING_SHORT_NAME_MAP).map(([full, short]) => [short, full as Ring])
+);
+
+export const REGION_LONG_NAME_MAP: Record<string, Region> = Object.fromEntries(
+    Object.entries(REGION_SHORT_NAME_MAP).map(([full, short]) => [short, full as Region])
+);
+
+/**
+ * Resolves a ring name: short name → full name, full name → unchanged.
+ * Unknown values pass through as-is.
+ */
+export function resolveRing(input: string): string {
+    const lower = input.toLowerCase();
+    // Check if it's already a full name
+    if (lower in RING_SHORT_NAME_MAP) return lower;
+    // Check if it's a short name
+    if (lower in RING_LONG_NAME_MAP) return RING_LONG_NAME_MAP[lower];
+    // Unknown — pass through
+    return input;
+}
+
+/**
+ * Resolves a region name: short name → full name, full name → unchanged.
+ * Unknown values pass through as-is.
+ */
+export function resolveRegion(input: string): string {
+    const lower = input.toLowerCase();
+    // Check if it's already a full name
+    if (lower in REGION_SHORT_NAME_MAP) return lower;
+    // Check if it's a short name
+    if (lower in REGION_LONG_NAME_MAP) return REGION_LONG_NAME_MAP[lower];
+    // Unknown — pass through
+    return input;
+}

--- a/src/common/statusChecker.ts
+++ b/src/common/statusChecker.ts
@@ -1,0 +1,454 @@
+/**
+ * Status checker — queries actual Azure / K8s resource status.
+ *
+ * Given a list of ExpandedResource[], it constructs the appropriate
+ * `az` or `kubectl` CLI command for each resource and runs them in
+ * parallel (with concurrency limit) to determine whether the resource
+ * exists in the cloud.
+ */
+
+import { execSync } from 'child_process';
+import { ExpandedResource, isParamValue, ParamValue } from '../compiler/types.js';
+import { RING_SHORT_NAME_MAP, REGION_SHORT_NAME_MAP, Ring, Region } from './resource.js';
+
+// ── Resource type → category mapping ─────────────────────────────────────────
+
+type ResourceCategory = 'azure-arm' | 'azure-ad' | 'kubernetes' | 'helm' | 'github' | 'unknown';
+
+const CATEGORY_MAP: Record<string, ResourceCategory> = {
+    // Azure ARM resources (queried via az resource show / type-specific CLI)
+    'AzureBlobStorage':               'azure-arm',
+    'ObjectStorage':                   'azure-arm',
+    'AzureContainerRegistry':         'azure-arm',
+    'ContainerRegistry':              'azure-arm',
+    'AzureContainerApp':              'azure-arm',
+    'ContainerApp':                   'azure-arm',
+    'AzureContainerAppEnvironment':   'azure-arm',
+    'ContainerAppEnvironment':        'azure-arm',
+    'AzureKeyVault':                  'azure-arm',
+    'AzureDnsZone':                   'azure-arm',
+    'DnsZone':                        'azure-arm',
+    'AzureLogAnalyticsWorkspace':     'azure-arm',
+    'LogSink':                        'azure-arm',
+    'AzureRedisEnterprise':           'azure-arm',
+    'AzurePostgreSQLFlexible':        'azure-arm',
+    'AzureFunctionApp':               'azure-arm',
+    'AzureAKSCluster':                'azure-arm',
+    'KubernetesCluster':              'azure-arm',
+
+    // Azure AD resources (queried via az ad app list)
+    'AzureServicePrincipal':          'azure-ad',
+    'ServicePrincipal':               'azure-ad',
+    'AzureADApp':                     'azure-ad',
+    'AppRegistration':                'azure-ad',
+
+    // Kubernetes resources (queried via kubectl)
+    'KubernetesNamespace':            'kubernetes',
+    'KubernetesDeployment':           'kubernetes',
+    'KubernetesService':              'kubernetes',
+    'KubernetesIngress':              'kubernetes',
+    'KubernetesConfigMap':            'kubernetes',
+    'KubernetesManifest':             'kubernetes',
+    'KubernetesServiceAccount':       'kubernetes',
+
+    // Helm releases (queried via helm list)
+    'KubernetesHelmRelease':          'helm',
+
+    // GitHub (no status check)
+    'GitHubWorkflow':                 'github',
+};
+
+// Azure ARM resource type provider strings
+const ARM_RESOURCE_TYPE_MAP: Record<string, string> = {
+    'AzureBlobStorage':               'Microsoft.Storage/storageAccounts',
+    'ObjectStorage':                   'Microsoft.Storage/storageAccounts',
+    'AzureContainerRegistry':         'Microsoft.ContainerRegistry/registries',
+    'ContainerRegistry':              'Microsoft.ContainerRegistry/registries',
+    'AzureContainerApp':              'Microsoft.App/containerApps',
+    'ContainerApp':                   'Microsoft.App/containerApps',
+    'AzureContainerAppEnvironment':   'Microsoft.App/managedEnvironments',
+    'ContainerAppEnvironment':        'Microsoft.App/managedEnvironments',
+    'AzureKeyVault':                  'Microsoft.KeyVault/vaults',
+    'AzureDnsZone':                   'Microsoft.Network/dnsZones',
+    'DnsZone':                        'Microsoft.Network/dnsZones',
+    'AzureLogAnalyticsWorkspace':     'Microsoft.OperationalInsights/workspaces',
+    'LogSink':                        'Microsoft.OperationalInsights/workspaces',
+    'AzureRedisEnterprise':           'Microsoft.Cache/redisEnterprise',
+    'AzurePostgreSQLFlexible':        'Microsoft.DBforPostgreSQL/flexibleServers',
+    'AzureFunctionApp':               'Microsoft.Web/sites',
+    'AzureAKSCluster':                'Microsoft.ContainerService/managedClusters',
+    'KubernetesCluster':              'Microsoft.ContainerService/managedClusters',
+};
+
+// Short resource type name map (matches Render.getShortResourceTypeName())
+const SHORT_TYPE_NAME_MAP: Record<string, string> = {
+    'AzureBlobStorage': 'abs',
+    'ObjectStorage': 'abs',
+    'AzureContainerRegistry': 'acr',
+    'ContainerRegistry': 'acr',
+    'AzureContainerApp': 'aca',
+    'ContainerApp': 'aca',
+    'AzureContainerAppEnvironment': 'acenv',
+    'ContainerAppEnvironment': 'acenv',
+    'AzureKeyVault': 'akv',
+    'AzureDnsZone': 'dnszone',
+    'DnsZone': 'dnszone',
+    'AzureLogAnalyticsWorkspace': 'law',
+    'LogSink': 'law',
+    'AzureRedisEnterprise': 'redis',
+    'AzurePostgreSQLFlexible': 'pg',
+    'AzureFunctionApp': 'func',
+    'AzureAKSCluster': 'aks',
+    'KubernetesCluster': 'aks',
+    'AzureServicePrincipal': 'sp',
+    'ServicePrincipal': 'sp',
+    'AzureADApp': 'aad',
+    'AppRegistration': 'aad',
+};
+
+// Whether a type uses connectors (hyphens) in resource name
+const SUPPORTS_CONNECTOR: Record<string, boolean> = {
+    'AzureBlobStorage': false,
+    'ObjectStorage': false,
+    'AzureContainerRegistry': false,
+    'ContainerRegistry': false,
+    'AzureContainerApp': true,
+    'ContainerApp': true,
+    'AzureContainerAppEnvironment': true,
+    'ContainerAppEnvironment': true,
+    'AzureKeyVault': false,
+    'AzureDnsZone': true,
+    'DnsZone': true,
+    'AzureLogAnalyticsWorkspace': true,
+    'LogSink': true,
+    'AzureRedisEnterprise': true,
+    'AzurePostgreSQLFlexible': true,
+    'AzureFunctionApp': true,
+    'AzureAKSCluster': true,
+    'KubernetesCluster': true,
+    'AzureServicePrincipal': true,
+    'ServicePrincipal': true,
+    'AzureADApp': true,
+    'AppRegistration': true,
+};
+
+// Global resource types (no region in naming)
+const GLOBAL_TYPES = new Set([
+    'AzureServicePrincipal', 'ServicePrincipal',
+    'AzureADApp', 'AppRegistration',
+    'AzureDnsZone', 'DnsZone',
+]);
+
+// K8s type → kubectl kind mapping
+const K8S_KIND_MAP: Record<string, string> = {
+    'KubernetesNamespace':      'namespace',
+    'KubernetesDeployment':     'deployment',
+    'KubernetesService':        'service',
+    'KubernetesIngress':        'ingress',
+    'KubernetesConfigMap':      'configmap',
+    'KubernetesServiceAccount': 'serviceaccount',
+};
+
+// ── Status result types ──────────────────────────────────────────────────────
+
+export type ResourceStatus = 'exists' | 'not-found' | 'error' | 'skip';
+
+export interface ResourceStatusResult {
+    resource: ExpandedResource;
+    status: ResourceStatus;
+    cloudName: string;   // The actual name used in Azure/K8s (e.g. "merlinsharedstgkrcabs", "alluneed (alluneed ns)")
+    detail?: string;     // e.g. "deployed", "appId: xxx", error message
+}
+
+// ── Naming helpers (mirror AzureResourceRender logic) ────────────────────────
+
+function getResourceGroupName(resource: ExpandedResource): string {
+    const projectPart = resource.project ?? 'shared';
+    const ringPart = `rg-${RING_SHORT_NAME_MAP[resource.ring as Ring] ?? resource.ring}`;
+    const regionPart = resource.region ? (REGION_SHORT_NAME_MAP[resource.region as Region] ?? resource.region) : '';
+    return [projectPart, ringPart, regionPart].filter(Boolean).join('-');
+}
+
+function getAzureResourceName(resource: ExpandedResource): string {
+    const projectPart = resource.project ?? 'shared';
+    const ringPart = RING_SHORT_NAME_MAP[resource.ring as Ring] ?? resource.ring;
+    const regionPart = resource.region ? (REGION_SHORT_NAME_MAP[resource.region as Region] ?? resource.region) : '';
+    const typePart = SHORT_TYPE_NAME_MAP[resource.type] ?? '';
+    const connector = (SUPPORTS_CONNECTOR[resource.type] ?? true) ? '-' : '';
+    return [projectPart, resource.name, ringPart, regionPart, typePart].filter(Boolean).join(connector);
+}
+
+function getDisplayName(resource: ExpandedResource): string {
+    // For SP/AAD, config.displayName takes precedence over generated name
+    const configDisplayName = resource.config?.displayName;
+    if (typeof configDisplayName === 'string') {
+        return configDisplayName;
+    }
+    // Handle ParamValue (e.g. "merlin-alluneed-aad-${ this.ring }")
+    if (isParamValue(configDisplayName)) {
+        return resolveParamValueLocally(configDisplayName, resource);
+    }
+    return getAzureResourceName(resource);
+}
+
+/**
+ * Resolves a ParamValue locally using only `this.ring` and `this.region`.
+ * Dependency expressions (${ Type.name.export }) cannot be resolved here,
+ * so they are replaced with a placeholder.
+ */
+function resolveParamValueLocally(pv: ParamValue, resource: ExpandedResource): string {
+    return pv.segments.map(seg => {
+        if (seg.type === 'literal') return seg.value;
+        if (seg.type === 'self') {
+            if (seg.field === 'ring') return resource.ring;
+            if (seg.field === 'region') return resource.region ?? '';
+        }
+        // dep references can't be resolved — use placeholder
+        return `<${seg.type}>`;
+    }).join('');
+}
+
+// ── Status checking ──────────────────────────────────────────────────────────
+
+function execQuiet(cmd: string): { ok: boolean; stdout: string } {
+    try {
+        const stdout = execSync(cmd, { encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+        return { ok: true, stdout };
+    } catch {
+        return { ok: false, stdout: '' };
+    }
+}
+
+/**
+ * Returns the human-readable cloud resource name for display.
+ * - Azure ARM: "resourceName (rgName)" e.g. "merlinsharedstgkrcabs (merlin-rg-stg-krc)"
+ * - Azure AD (SP/AAD): displayName e.g. "merlin-alluneed-aad-staging"
+ * - K8s: "name (namespace ns)" e.g. "alluneed (alluneed ns)" or just "alluneed" for namespaces
+ * - Helm: "releaseName (namespace ns)" e.g. "cert-manager (cert-manager ns)"
+ */
+export function getCloudResourceName(resource: ExpandedResource): string {
+    const category = CATEGORY_MAP[resource.type] ?? 'unknown';
+
+    switch (category) {
+        case 'azure-arm': {
+            if (resource.type === 'AzureDnsZone' || resource.type === 'DnsZone') {
+                const dnsName = resource.config?.dnsName as string | undefined;
+                return dnsName ?? getAzureResourceName(resource);
+            }
+            const name = getAzureResourceName(resource);
+            const rg = getResourceGroupName(resource);
+            return `${name} (${rg})`;
+        }
+        case 'azure-ad':
+            return getDisplayName(resource);
+        case 'kubernetes': {
+            const kind = K8S_KIND_MAP[resource.type];
+            if (kind === 'namespace') {
+                const ns = resource.config?.namespace as string ?? resource.name;
+                return `namespace/${ns}`;
+            }
+            const namespace = resource.config?.namespace as string | undefined;
+            return namespace ? `${resource.name} (${namespace} ns)` : resource.name;
+        }
+        case 'helm': {
+            const releaseName = resource.config?.releaseName as string ?? resource.name;
+            const namespace = resource.config?.namespace as string | undefined;
+            return namespace ? `${releaseName} (${namespace} ns)` : releaseName;
+        }
+        default:
+            return resource.name;
+    }
+}
+
+function checkAzureArmResource(resource: ExpandedResource): ResourceStatusResult {
+    const rg = getResourceGroupName(resource);
+    const name = getAzureResourceName(resource);
+    const armType = ARM_RESOURCE_TYPE_MAP[resource.type];
+    const cloudName = getCloudResourceName(resource);
+
+    if (!armType) {
+        return { resource, status: 'skip', cloudName, detail: 'Unknown ARM type' };
+    }
+
+    // DNS zones are global (no region in RG name) — use a special RG calculation
+    // For DNS zones, the resource name is actually the zone name from config, not the generated name
+    if (resource.type === 'AzureDnsZone' || resource.type === 'DnsZone') {
+        const dnsName = resource.config?.dnsName as string | undefined;
+        const zoneName = dnsName ?? name;
+        // Try to find the zone by listing all zones matching the name
+        const { ok, stdout } = execQuiet(
+            `az network dns zone list --query "[?name=='${zoneName}'].{name:name, rg:resourceGroup}" -o tsv`
+        );
+        if (ok && stdout.length > 0) {
+            return { resource, status: 'exists', cloudName };
+        }
+        return { resource, status: 'not-found', cloudName };
+    }
+
+    const { ok } = execQuiet(
+        `az resource show --resource-group "${rg}" --resource-type "${armType}" --name "${name}" --query id -o tsv`
+    );
+    return { resource, status: ok ? 'exists' : 'not-found', cloudName };
+}
+
+function checkAzureAdResource(resource: ExpandedResource): ResourceStatusResult {
+    const displayName = getDisplayName(resource);
+    const cloudName = displayName;
+    // displayName may contain unresolved expressions — skip those
+    if (displayName.includes('${') || displayName.includes('<dep>')) {
+        // Try with the generated name fallback
+        const fallback = getAzureResourceName(resource);
+        const { ok, stdout } = execQuiet(
+            `az ad app list --filter "displayName eq '${fallback}'" --query "[0].appId" -o tsv`
+        );
+        if (ok && stdout.length > 0) {
+            return { resource, status: 'exists', cloudName: fallback, detail: `appId: ${stdout}` };
+        }
+        return { resource, status: 'not-found', cloudName: fallback, detail: 'displayName has unresolved expressions' };
+    }
+
+    const { ok, stdout } = execQuiet(
+        `az ad app list --filter "displayName eq '${displayName}'" --query "[0].appId" -o tsv`
+    );
+    if (ok && stdout.length > 0) {
+        return { resource, status: 'exists', cloudName, detail: `appId: ${stdout}` };
+    }
+    return { resource, status: 'not-found', cloudName };
+}
+
+function checkKubernetesResource(resource: ExpandedResource): ResourceStatusResult {
+    const kind = K8S_KIND_MAP[resource.type];
+    const cloudName = getCloudResourceName(resource);
+    if (!kind) {
+        // KubernetesManifest — skip, we don't know the kind
+        return { resource, status: 'skip', cloudName, detail: 'Manifest — cannot determine kind' };
+    }
+
+    const namespace = resource.config?.namespace as string | undefined;
+    const name = resource.name;
+
+    if (kind === 'namespace') {
+        const ns = namespace ?? name;
+        const { ok } = execQuiet(`kubectl get namespace "${ns}" -o name`);
+        return { resource, status: ok ? 'exists' : 'not-found', cloudName };
+    }
+
+    if (!namespace) {
+        return { resource, status: 'error', cloudName, detail: 'No namespace in config' };
+    }
+
+    const { ok } = execQuiet(`kubectl get ${kind} "${name}" -n "${namespace}" -o name`);
+    return { resource, status: ok ? 'exists' : 'not-found', cloudName };
+}
+
+function checkHelmRelease(resource: ExpandedResource): ResourceStatusResult {
+    const releaseName = resource.config?.releaseName as string | undefined;
+    const namespace = resource.config?.namespace as string | undefined;
+    const cloudName = getCloudResourceName(resource);
+
+    if (!releaseName || !namespace) {
+        return { resource, status: 'error', cloudName, detail: 'Missing releaseName or namespace' };
+    }
+
+    // Use helm list with filter — much lighter than helm status (which dumps all manifests)
+    const { ok, stdout } = execQuiet(
+        `helm list -n "${namespace}" --filter "^${releaseName}$" --output json`
+    );
+    if (ok && stdout.length > 2) { // '[]' is empty
+        try {
+            const releases = JSON.parse(stdout);
+            if (Array.isArray(releases) && releases.length > 0) {
+                const status = releases[0]?.status ?? 'unknown';
+                return { resource, status: 'exists', cloudName, detail: status };
+            }
+        } catch { /* fall through */ }
+    }
+    return { resource, status: 'not-found', cloudName };
+}
+
+function checkSingle(resource: ExpandedResource): ResourceStatusResult {
+    const category = CATEGORY_MAP[resource.type] ?? 'unknown';
+    const cloudName = getCloudResourceName(resource);
+
+    switch (category) {
+        case 'azure-arm':
+            return checkAzureArmResource(resource);
+        case 'azure-ad':
+            return checkAzureAdResource(resource);
+        case 'kubernetes':
+            return checkKubernetesResource(resource);
+        case 'helm':
+            return checkHelmRelease(resource);
+        case 'github':
+            return { resource, status: 'skip', cloudName, detail: 'GitHub workflow' };
+        default:
+            return { resource, status: 'skip', cloudName, detail: `Unknown type: ${resource.type}` };
+    }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Checks the actual status of each resource by querying Azure / K8s.
+ * Returns results in the same order as the input array.
+ *
+ * Runs checks sequentially to avoid overwhelming CLI tools, but each check
+ * has a 15s timeout so the total time is bounded.
+ */
+export function checkResourceStatuses(resources: ExpandedResource[]): ResourceStatusResult[] {
+    return resources.map(r => {
+        try {
+            return checkSingle(r);
+        } catch (error) {
+            return {
+                resource: r,
+                status: 'error' as ResourceStatus,
+                cloudName: getCloudResourceName(r),
+                detail: error instanceof Error ? error.message : String(error),
+            };
+        }
+    });
+}
+
+/**
+ * De-duplicates resources by type+name (ignoring ring/region) and aggregates
+ * status across all instances. If ANY instance exists, the aggregate is 'exists'.
+ */
+export interface AggregatedStatus {
+    type: string;
+    name: string;
+    project: string;
+    rings: Set<string>;
+    regions: Set<string>;
+    statuses: Map<string, ResourceStatus>;  // key: "ring:region"
+    details: Map<string, string>;           // key: "ring:region"
+}
+
+export function aggregateStatuses(results: ResourceStatusResult[]): AggregatedStatus[] {
+    const grouped = new Map<string, AggregatedStatus>();
+
+    for (const r of results) {
+        const key = `${r.resource.type}.${r.resource.name}`;
+        const ringRegionKey = `${r.resource.ring}:${r.resource.region ?? 'global'}`;
+
+        const existing = grouped.get(key);
+        if (existing) {
+            existing.rings.add(r.resource.ring);
+            if (r.resource.region) existing.regions.add(r.resource.region);
+            existing.statuses.set(ringRegionKey, r.status);
+            if (r.detail) existing.details.set(ringRegionKey, r.detail);
+        } else {
+            grouped.set(key, {
+                type: r.resource.type,
+                name: r.resource.name,
+                project: r.resource.project ?? 'shared',
+                rings: new Set([r.resource.ring]),
+                regions: new Set(r.resource.region ? [r.resource.region] : []),
+                statuses: new Map([[ringRegionKey, r.status]]),
+                details: new Map(r.detail ? [[ringRegionKey, r.detail]] : []),
+            });
+        }
+    }
+
+    return [...grouped.values()];
+}

--- a/src/common/test/resolveNames.test.ts
+++ b/src/common/test/resolveNames.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+    resolveRing,
+    resolveRegion,
+    RING_LONG_NAME_MAP,
+    REGION_LONG_NAME_MAP,
+} from '../resolveNames.js';
+
+describe('resolveRing', () => {
+    it('resolves short names to full names', () => {
+        expect(resolveRing('tst')).toBe('test');
+        expect(resolveRing('stg')).toBe('staging');
+        expect(resolveRing('prd')).toBe('production');
+    });
+
+    it('passes through full names unchanged', () => {
+        expect(resolveRing('test')).toBe('test');
+        expect(resolveRing('staging')).toBe('staging');
+        expect(resolveRing('production')).toBe('production');
+    });
+
+    it('is case-insensitive', () => {
+        expect(resolveRing('TST')).toBe('test');
+        expect(resolveRing('Stg')).toBe('staging');
+        expect(resolveRing('PRODUCTION')).toBe('production');
+    });
+
+    it('passes through unknown values as-is', () => {
+        expect(resolveRing('unknown')).toBe('unknown');
+        expect(resolveRing('dev')).toBe('dev');
+    });
+});
+
+describe('resolveRegion', () => {
+    it('resolves short names to full names (Azure)', () => {
+        expect(resolveRegion('krc')).toBe('koreacentral');
+        expect(resolveRegion('eas')).toBe('eastasia');
+        expect(resolveRegion('eus')).toBe('eastus');
+        expect(resolveRegion('wus')).toBe('westus');
+        expect(resolveRegion('krs')).toBe('koreasouth');
+    });
+
+    it('resolves short names to full names (Alibaba)', () => {
+        expect(resolveRegion('hzh')).toBe('cn-hangzhou');
+        expect(resolveRegion('sha')).toBe('cn-shanghai');
+        expect(resolveRegion('bej')).toBe('cn-beijing');
+        expect(resolveRegion('sg1')).toBe('ap-southeast-1');
+    });
+
+    it('passes through full names unchanged', () => {
+        expect(resolveRegion('koreacentral')).toBe('koreacentral');
+        expect(resolveRegion('eastasia')).toBe('eastasia');
+        expect(resolveRegion('cn-hangzhou')).toBe('cn-hangzhou');
+    });
+
+    it('is case-insensitive', () => {
+        expect(resolveRegion('KRC')).toBe('koreacentral');
+        expect(resolveRegion('EAS')).toBe('eastasia');
+    });
+
+    it('passes through unknown values as-is', () => {
+        expect(resolveRegion('us-west-2')).toBe('us-west-2');
+        expect(resolveRegion('unknown')).toBe('unknown');
+    });
+});
+
+describe('reverse maps', () => {
+    it('RING_LONG_NAME_MAP covers all short names', () => {
+        expect(RING_LONG_NAME_MAP).toEqual({
+            'tst': 'test',
+            'stg': 'staging',
+            'prd': 'production',
+        });
+    });
+
+    it('REGION_LONG_NAME_MAP covers all short names', () => {
+        expect(REGION_LONG_NAME_MAP).toEqual({
+            'eus': 'eastus',
+            'wus': 'westus',
+            'eas': 'eastasia',
+            'krc': 'koreacentral',
+            'krs': 'koreasouth',
+            'hzh': 'cn-hangzhou',
+            'sha': 'cn-shanghai',
+            'bej': 'cn-beijing',
+            'sg1': 'ap-southeast-1',
+        });
+    });
+});

--- a/src/merlin.ts
+++ b/src/merlin.ts
@@ -2,7 +2,12 @@ import { Command } from 'commander';
 import { Compiler } from './common/compiler.js';
 import { execaCommand } from 'execa';
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
 import * as path from 'path';
+import { resolveRing, resolveRegion } from './common/resolveNames.js';
+import { loadCLIDefaults } from './cli/defaults.js';
+import { confirmDeploy } from './cli/confirm.js';
+import { runInit, TemplateName } from './cli/init.js';
 
 const program = new Command();
 
@@ -19,15 +24,59 @@ function parseAlsoPaths(also: string | string[] | undefined): string[] {
         .filter(Boolean);
 }
 
+/**
+ * Checks that the resource path exists. If not, prints a friendly error
+ * with guidance on how to fix it, then exits.
+ */
+function ensurePathExists(resourcePath: string): void {
+    if (!existsSync(resourcePath)) {
+        console.error(`❌ Resource path not found: ${resourcePath}\n`);
+        if (resourcePath === './merlin-resources' || resourcePath === 'merlin-resources') {
+            console.error('   This is a new project? Run merlin init to get started:\n');
+            console.error('     merlin init <project-name>              # Web service template');
+            console.error('     merlin init <project-name> --with-auth  # With OAuth2 authentication\n');
+            console.error('   Or specify a different path:\n');
+            console.error('     merlin <command> ./path/to/resources');
+        } else {
+            console.error(`   Directory "${resourcePath}" does not exist.`);
+            console.error('   Check the path or run: merlin init <project-name>');
+        }
+        process.exit(1);
+    }
+}
+
 program
     .name('merlin')
     .description('CLI tool for Infrastructure as Code deployment and management')
-    .version('0.2.0');
+    .version('0.2.0')
+    .addHelpText('after', `
+Quick Start:
+  $ merlin init myapp                  Create a new project with resource templates
+  $ merlin init myapp --with-auth      Include OAuth2 authentication resources
+  $ merlin compile                     Compile YAML resources to TypeScript
+  $ merlin deploy                      Preview deployment commands (dry-run)
+  $ merlin deploy --execute            Execute the deployment
+  $ merlin list                        List resources and check cloud status
+
+Ring/Region Short Names:
+  Rings:    tst (test), stg (staging), prd (production)
+  Regions:  krc (koreacentral), eas (eastasia), eus (eastus), wus (westus)
+
+Examples:
+  $ merlin deploy -r stg --region krc              Deploy to staging/koreacentral
+  $ merlin deploy -r prd --execute --yes            Deploy to production (CI mode)
+  $ merlin deploy shared-k8s-resource --execute --all  Deploy shared infra to all rings
+  $ merlin list -r stg --region krc --no-status     List resources without status check
+
+Help for a specific command:
+  $ merlin help <command>              e.g. merlin help deploy, merlin help init
+  $ merlin <command> --help            e.g. merlin deploy --help
+`);
 
 program
     .command('compile')
     .description('Compile YAML resource definitions to TypeScript')
-    .argument('[path]', 'Path to YAML file or directory', './resources')
+    .argument('[path]', 'Path to YAML file or directory', './merlin-resources')
     .option('-i, --input <path>', 'Path to YAML resource definitions directory (overrides [path] argument)')
     .option('--also <paths...>', 'Additional resource directories to compile alongside the main path (repeatable, also supports comma-separated)')
     .option('-o, --output <path>', 'Output directory', '.merlin')
@@ -37,6 +86,7 @@ program
     .option('--no-shared', 'Do not auto-include shared resources from the merlin package')
     .action(async (argPath, options) => {
         const inputPath = options.input ?? argPath;
+        ensurePathExists(inputPath);
         const extraPaths = parseAlsoPaths(options.also);
         const compiler = new Compiler();
 
@@ -101,23 +151,63 @@ program
 program
     .command('deploy')
     .description('Deploy infrastructure resources')
-    .argument('[path]', 'Path to resource configuration file or directory', './resources')
+    .argument('[path]', 'Path to resource configuration file or directory', './merlin-resources')
     .option('-i, --input <path>', 'Path to YAML resource definitions directory (overrides [path] argument)')
     .option('--also <paths...>', 'Additional resource directories to compile alongside the main path (repeatable, also supports comma-separated)')
     .option('-e, --execute', 'Actually execute the deployment (default is dry-run)')
-    .option('-r, --ring <ring>', 'Target ring (test, staging, production)')
-    .option('--region <region>', 'Target region (eastus, westus, krc)')
+    .option('-r, --ring <ring>', 'Target ring (test, staging, production, or short: tst, stg, prd)')
+    .option('--region <region>', 'Target region (koreacentral, eastasia, or short: krc, eas)')
     .option('--dir <path>', 'Compiled output directory', '.merlin')
     .option('-o, --output-file <file>', 'Write generated commands to file')
     .option('-c, --concurrency <number>', 'Max parallel resource deployments per level (default: 4)', '4')
     .option('--cloud <cloud>', 'Cloud provider: azure (default) | alibaba', 'azure')
     .option('--no-shared', 'Do not auto-include shared resources from the merlin package')
+    .option('--all', 'Confirm deployment to all rings (required with --execute when no --ring)')
+    .option('-y, --yes', 'Skip interactive confirmations (for CI/CD)')
+    .addHelpText('after', `
+Defaults:
+  If merlin-resources/merlin.yml exists, --ring and --region default to its first values.
+  Default mode is dry-run (preview commands). Add --execute to actually deploy.
+
+Safety:
+  --execute without --ring requires --all (prevents accidental all-ring deploy)
+  --execute with --ring production requires interactive confirmation (or --yes for CI)
+
+Examples:
+  $ merlin deploy                              Dry-run with merlin.yml defaults
+  $ merlin deploy --execute                    Deploy to default ring from merlin.yml
+  $ merlin deploy -r stg --region krc          Dry-run staging/koreacentral
+  $ merlin deploy -r stg --execute             Deploy to staging
+  $ merlin deploy -r prd --execute --yes       Deploy to production (CI, skip confirm)
+  $ merlin deploy shared-k8s-resource --execute --all  Deploy shared infra to all rings
+  $ merlin deploy --also shared-resource --execute     Include shared resources
+`)
     .action(async (argPath, options) => {
         const resourcePath = options.input ?? argPath;
+        ensurePathExists(resourcePath);
         const outputPath = options.dir;
         const extraPaths = parseAlsoPaths(options.also);
 
         try {
+            // Load merlin.yml defaults
+            const defaults = loadCLIDefaults(resourcePath);
+            if (defaults?.project) {
+                console.log(`📋 Project: ${defaults.project} (from merlin.yml)`);
+            }
+
+            // Resolve ring/region: CLI explicit value > merlin.yml default
+            const ring = options.ring ? resolveRing(options.ring) : defaults?.ring;
+            const region = options.region ? resolveRegion(options.region) : defaults?.region;
+
+            // Safety check
+            const proceed = await confirmDeploy({
+                execute: !!options.execute,
+                ring,
+                all: !!options.all,
+                yes: !!options.yes,
+            });
+            if (!proceed) process.exit(1);
+
             // Auto-compile before deployment
             console.log('🔨 Compiling resources...');
             const compiler = new Compiler();
@@ -149,12 +239,12 @@ program
             // Build the deploy command arguments
             const args: string[] = [];
 
-            if (options.ring) {
-                args.push('--ring', options.ring);
+            if (ring) {
+                args.push('--ring', ring);
             }
 
-            if (options.region) {
-                args.push('--region', options.region);
+            if (region) {
+                args.push('--region', region);
             }
 
             if (options.outputFile) {
@@ -200,12 +290,13 @@ program
 program
     .command('validate')
     .description('Validate resource configuration files')
-    .argument('[path]', 'Path to resource configuration file or directory', './resources')
+    .argument('[path]', 'Path to resource configuration file or directory', './merlin-resources')
     .option('-i, --input <path>', 'Path to YAML resource definitions directory (overrides [path] argument)')
     .option('--also <paths...>', 'Additional resource directories to validate alongside the main path (repeatable, also supports comma-separated)')
     .option('--no-shared', 'Do not auto-include shared resources from the merlin package')
     .action(async (argPath, options) => {
         const inputPath = options.input ?? argPath;
+        ensurePathExists(inputPath);
         const extraPaths = parseAlsoPaths(options.also);
         // Auto-compile before validation (user preference)
         console.log('🔨 Compiling resources...');
@@ -246,6 +337,149 @@ program
             process.exit(1);
         }
     });
+
+program
+    .command('list')
+    .description('List all resources managed by Merlin and check their actual status')
+    .argument('[path]', 'Path to resource configuration file or directory', './merlin-resources')
+    .option('-i, --input <path>', 'Path to YAML resource definitions directory (overrides [path] argument)')
+    .option('--also <paths...>', 'Additional resource directories (repeatable, also supports comma-separated)')
+    .option('--no-shared', 'Do not auto-include shared resources from the merlin package')
+    .option('-r, --ring <ring>', 'Filter by ring (test, staging, production, or short: tst, stg, prd)')
+    .option('--region <region>', 'Filter by region (koreacentral, eastasia, or short: krc, eas)')
+    .option('--no-status', 'Skip querying actual Azure/K8s resource status')
+    .option('--json', 'Output as JSON')
+    .addHelpText('after', `
+Defaults:
+  If merlin-resources/merlin.yml exists, --ring and --region default to its first values.
+  By default, queries actual Azure/K8s status (use --no-status to skip).
+
+Examples:
+  $ merlin list                                List with defaults from merlin.yml
+  $ merlin list -r stg --region krc            List staging/koreacentral resources
+  $ merlin list --no-status                    List without cloud status check (fast)
+  $ merlin list --json                         Output as JSON (for scripting)
+  $ merlin list --json --no-status | jq .      Fast JSON listing
+`)
+    .action(async (argPath, options) => {
+        const inputPath = options.input ?? argPath;
+        ensurePathExists(inputPath);
+        const extraPaths = parseAlsoPaths(options.also);
+        const compiler = new Compiler();
+
+        // Load merlin.yml defaults for ring/region
+        const defaults = loadCLIDefaults(inputPath);
+
+        // Resolve ring/region: CLI explicit value > merlin.yml default
+        const ring = options.ring ? resolveRing(options.ring) : defaults?.ring;
+        const region = options.region ? resolveRegion(options.region) : defaults?.region;
+
+        try {
+            const resources = await compiler.list({
+                inputPath,
+                inputPaths: extraPaths.length > 0 ? extraPaths : undefined,
+                noShared: !options.shared,
+                ring,
+                region,
+            });
+
+            if (resources.length === 0) {
+                console.log('No resources found.');
+                return;
+            }
+
+            // Check actual status unless --no-status is set
+            const checkStatus = options.status !== false;
+            let statusResults: import('./common/statusChecker.js').ResourceStatusResult[] | undefined;
+
+            if (checkStatus) {
+                const { checkResourceStatuses } = await import('./common/statusChecker.js');
+                console.error(`🔍 Checking status of ${resources.length} resource instances...\n`);
+                statusResults = checkResourceStatuses(resources);
+            }
+
+            if (options.json) {
+                const output = resources.map((r, i) => ({
+                    name: r.name, type: r.type, ring: r.ring,
+                    region: r.region ?? 'global', project: r.project ?? 'shared',
+                    ...(statusResults ? {
+                        cloudName: statusResults[i].cloudName,
+                        status: statusResults[i].status,
+                        detail: statusResults[i].detail,
+                    } : {}),
+                }));
+                console.log(JSON.stringify(output, null, 2));
+                return;
+            }
+
+            // Build a status lookup map: "type.name:ring:region" → status result
+            const statusMap = new Map<string, import('./common/statusChecker.js').ResourceStatusResult>();
+            if (statusResults) {
+                for (const sr of statusResults) {
+                    const key = `${sr.resource.type}.${sr.resource.name}:${sr.resource.ring}:${sr.resource.region ?? 'global'}`;
+                    statusMap.set(key, sr);
+                }
+            }
+
+            if (checkStatus) {
+                // Status mode: one line per instance, showing the full cloud resource name
+                const W_STATUS = 3, W_TYPE = 28, W_CLOUD_NAME = 50;
+                console.log(`  ${''.padEnd(W_STATUS)} ${'Type'.padEnd(W_TYPE)} ${'Cloud Resource Name'.padEnd(W_CLOUD_NAME)} Detail`);
+                console.log(`  ${''.padEnd(W_STATUS)} ${'─'.repeat(W_TYPE)} ${'─'.repeat(W_CLOUD_NAME)} ${'─'.repeat(20)}`);
+
+                for (const r of resources) {
+                    const statusKey = `${r.type}.${r.name}:${r.ring}:${r.region ?? 'global'}`;
+                    const sr = statusMap.get(statusKey);
+                    const icon = statusIcon(sr?.status);
+                    const cloudName = sr?.cloudName ?? r.name;
+                    const detail = sr?.detail ?? '';
+                    console.log(`  ${icon}  ${r.type.padEnd(W_TYPE)} ${cloudName.padEnd(W_CLOUD_NAME)} ${detail}`);
+                }
+            } else {
+                // No-status mode: show cloud name via getCloudResourceName
+                const { getCloudResourceName } = await import('./common/statusChecker.js');
+                const W_TYPE = 28, W_CLOUD_NAME = 50, W_RING = 12;
+                console.log('');
+                console.log(`  ${'Type'.padEnd(W_TYPE)} ${'Cloud Resource Name'.padEnd(W_CLOUD_NAME)} ${'Ring'.padEnd(W_RING)} Region`);
+                console.log(`  ${'─'.repeat(W_TYPE)} ${'─'.repeat(W_CLOUD_NAME)} ${'─'.repeat(W_RING)} ${'─'.repeat(15)}`);
+
+                for (const r of resources) {
+                    const cloudName = getCloudResourceName(r);
+                    console.log(`  ${r.type.padEnd(W_TYPE)} ${cloudName.padEnd(W_CLOUD_NAME)} ${r.ring.padEnd(W_RING)} ${r.region ?? 'global'}`);
+                }
+            }
+
+            // Summary
+            const total = resources.length;
+            const uniqueCount = new Set(resources.map(r => `${r.type}.${r.name}`)).size;
+            if (statusResults) {
+                const exists = statusResults.filter(r => r.status === 'exists').length;
+                const notFound = statusResults.filter(r => r.status === 'not-found').length;
+                const skipped = statusResults.filter(r => r.status === 'skip').length;
+                const errored = statusResults.filter(r => r.status === 'error').length;
+                console.log('');
+                console.log(`  Total: ${uniqueCount} resources (${total} instances)`);
+                console.log(`  ✅ ${exists} exists   ❌ ${notFound} not found${skipped > 0 ? `   ⊘ ${skipped} skipped` : ''}${errored > 0 ? `   ⚠️  ${errored} errors` : ''}`);
+            } else {
+                console.log('');
+                console.log(`  Total: ${uniqueCount} resources (${total} instances)`);
+            }
+            console.log('');
+        } catch (error) {
+            console.error('❌ Failed to list resources:', error instanceof Error ? error.message : error);
+            process.exit(1);
+        }
+    });
+
+function statusIcon(status?: string): string {
+    switch (status) {
+        case 'exists':    return '✅';
+        case 'not-found': return '❌';
+        case 'error':     return '⚠️ ';
+        case 'skip':      return '⊘ ';
+        default:          return '  ';
+    }
+}
 
 program
     .command('prerequisites')
@@ -331,6 +565,43 @@ program
             console.log('   merlin prerequisites --install');
             process.exit(1);
         }
+    });
+
+program
+    .command('init')
+    .description('Initialize a new Merlin project with resource templates')
+    .argument('[name]', 'Project name (defaults to current directory name)')
+    .option('-t, --template <type>', 'Template type: web (default), worker, api, minimal', 'web')
+    .option('--with-auth', 'Include OAuth2 proxy + Azure AD App authentication resources')
+    .option('--dir <path>', 'Output directory', './merlin-resources')
+    .addHelpText('after', `
+Templates:
+  web (default)   Web service with Ingress + ServiceAccount + SecretProviderClass (4 files)
+  web --with-auth Web service + OAuth2 proxy + Azure AD App Registration (7 files)
+  api             API service with Ingress, no auth annotations (4 files)
+  worker          Background worker, no Ingress (4 files)
+  minimal         Just merlin.yml + KubernetesApp (2 files)
+
+Examples:
+  $ merlin init myapp                        Web service template
+  $ merlin init myapp --with-auth            Web + OAuth2 authentication (7 files)
+  $ merlin init myworker --template worker   Background worker template
+  $ merlin init myapi --template api         API service template
+
+Generated files (web template):
+  merlin-resources/
+    merlin.yml              Project config (ring, region defaults)
+    <name>.yml              KubernetesApp (main service)
+    <name>workloadsa.yml    ServiceAccount (Workload Identity)
+    <name>secretprovider.yml SecretProviderClass (Key Vault CSI)
+`)
+    .action(async (name, options) => {
+        const projectName = name || path.basename(process.cwd());
+        await runInit(projectName, {
+            template: options.template as TemplateName,
+            withAuth: !!options.withAuth,
+            dir: options.dir,
+        });
     });
 
 program.parse();

--- a/synapse-k8s-resource/synapsedashboarddeployment.yml
+++ b/synapse-k8s-resource/synapsedashboarddeployment.yml
@@ -1,6 +1,6 @@
 name: synapse-dashboard
 type: KubernetesDeployment
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapsedashboardingress.yml
+++ b/synapse-k8s-resource/synapsedashboardingress.yml
@@ -1,6 +1,6 @@
 name: synapse-dashboard
 type: KubernetesIngress
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapsedashboardsvc.yml
+++ b/synapse-k8s-resource/synapsedashboardsvc.yml
@@ -1,6 +1,6 @@
 name: synapse-dashboard
 type: KubernetesService
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapsegatewaydeployment.yml
+++ b/synapse-k8s-resource/synapsegatewaydeployment.yml
@@ -1,6 +1,6 @@
 name: synapse-gateway
 type: KubernetesDeployment
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapsegatewaysvc.yml
+++ b/synapse-k8s-resource/synapsegatewaysvc.yml
@@ -1,6 +1,6 @@
 name: synapse-gateway
 type: KubernetesService
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapsesecretprovider.yml
+++ b/synapse-k8s-resource/synapsesecretprovider.yml
@@ -1,6 +1,6 @@
 name: synapse-secret-provider
 type: KubernetesManifest
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapsesharedconfig.yml
+++ b/synapse-k8s-resource/synapsesharedconfig.yml
@@ -1,6 +1,6 @@
 name: synapse-shared-config
 type: KubernetesConfigMap
-project: merlin
+project: synapse
 ring:
   - test
   - staging

--- a/synapse-k8s-resource/synapseworkloadsa.yml
+++ b/synapse-k8s-resource/synapseworkloadsa.yml
@@ -1,6 +1,6 @@
 name: synapse-workload-sa
 type: KubernetesServiceAccount
-project: merlin
+project: synapse
 ring:
   - test
   - staging


### PR DESCRIPTION
## Summary

- **`merlin init`**: One command to generate full resource YAML templates (4 template types + `--with-auth` for OAuth2)
- **Short names**: `merlin deploy -r stg --region krc` instead of `--ring staging --region koreacentral`
- **Auto-defaults**: CLI reads `merlin.yml` for default ring/region — zero flags needed for common operations
- **Deploy safety**: `--execute` without `--ring` requires `--all`; production requires interactive confirmation
- **Friendly errors**: Missing resource path suggests `merlin init` instead of raw ENOENT
- **Project rename**: All resource YAML `project: merlin` → correct names (`brainly`, `trinity`, `synapse`, `alluneed`); all hardcoded `merlin-rg-*`/`merlinshared*` → `brainly-rg-*`/`brainlyshared*`
- **Default path**: `./resources` → `./merlin-resources` across all commands

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test resolveNames` — 11 tests pass
- [x] `merlin init myapp` generates 4 files, `merlin init myapp --with-auth` generates 7 files
- [x] `merlin list` / `merlin compile` / `merlin deploy` / `merlin validate` show friendly errors when path missing
- [x] `merlin list -r stg --region krc` works with short names
- [x] `merlin help init` / `merlin help deploy` show examples and defaults
- [ ] No generated YAML contains `merlin` as project name (only as tool label `managed-by: merlin`)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)