### PR TITLE
feat: auto-ensure K8s namespace before deploying resources

### DIFF
--- a/shared-k8s-resource/sharedaks.yml
+++ b/shared-k8s-resource/sharedaks.yml
@@ -29,11 +29,6 @@ defaultConfig:
   tags:
     merlin: "true"
     env: ${ this.ring }
-  # namespaces shared across all projects
-  namespaces:
-    - synapse
-    - trinity
-    - alluneed
 
 specificConfig:
   - region: koreacentral

--- a/src/kubernetes/kubernetesCluster.ts
+++ b/src/kubernetes/kubernetesCluster.ts
@@ -46,13 +46,6 @@ export interface KubernetesClusterConfig extends ResourceSchema {
     enableCsiSecretProvider?: boolean;      // --enable-addons azure-keyvault-secrets-provider
     enableSecretRotation?: boolean;         // --enable-secret-rotation (CSI addon)
 
-    // ── Namespaces to create after cluster provisioning ───────────────────────
-    /**
-     * List of Kubernetes namespaces to create after the cluster is provisioned.
-     * Each entry is a namespace name (e.g. 'trinity', 'alluneed', 'synapse').
-     */
-    namespaces?: string[];
-
     // ── ACR integration ─────────────────────────────────────────────────────
     /**
      * ACR resource name or ID to attach for image pulling.
@@ -121,16 +114,6 @@ export class AzureAKSRender extends AzureResourceRender {
                 command: 'bash',
                 args: ['-c', `az aks update --name ${this.getResourceName(resource)} --resource-group ${this.getResourceGroupName(resource)} --attach-acr ${config.attachAcr} || true`],
             });
-        }
-
-        // Create namespaces after provisioning
-        if (config.namespaces && config.namespaces.length > 0) {
-            for (const ns of config.namespaces) {
-                ret.push({
-                    command: 'bash',
-                    args: ['-c', `kubectl create namespace ${ns} --dry-run=client -o yaml | kubectl apply -f -`],
-                });
-            }
         }
 
         return ret;

--- a/src/kubernetes/kubernetesConfigMap.ts
+++ b/src/kubernetes/kubernetesConfigMap.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
-import { manifestToYaml } from './kubernetesNamespace.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_CONFIG_MAP_TYPE = 'KubernetesConfigMap';
 
@@ -36,7 +36,9 @@ export class KubernetesConfigMapRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {

--- a/src/kubernetes/kubernetesDeployment.ts
+++ b/src/kubernetes/kubernetesDeployment.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
-import { manifestToYaml } from './kubernetesNamespace.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_DEPLOYMENT_TYPE = 'KubernetesDeployment';
 
@@ -117,7 +117,9 @@ export class KubernetesDeploymentRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {

--- a/src/kubernetes/kubernetesHelmRelease.ts
+++ b/src/kubernetes/kubernetesHelmRelease.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
-import { manifestToYaml } from './kubernetesNamespace.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_HELM_RELEASE_TYPE = 'KubernetesHelmRelease';
 
@@ -76,7 +76,9 @@ export class KubernetesHelmReleaseRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {

--- a/src/kubernetes/kubernetesIngress.ts
+++ b/src/kubernetes/kubernetesIngress.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
-import { manifestToYaml } from './kubernetesNamespace.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_INGRESS_TYPE = 'KubernetesIngress';
 
@@ -104,7 +104,9 @@ export class KubernetesIngressRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {

--- a/src/kubernetes/kubernetesManifest.ts
+++ b/src/kubernetes/kubernetesManifest.ts
@@ -1,5 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
+import { ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_MANIFEST_TYPE = 'KubernetesManifest';
 
@@ -53,7 +54,12 @@ export class KubernetesManifestRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        // Extract namespace from config.namespace or from raw manifest content
+        const config = resolved.config as Record<string, unknown>;
+        const ns = (config.namespace as string | undefined)
+            ?? KubernetesManifestRender.extractNamespaceFromManifest(config.manifest as string);
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {
@@ -72,5 +78,17 @@ export class KubernetesManifestRender implements Render {
 
     private static isKubernetesManifestResource(resource: Resource): resource is KubernetesManifestResource {
         return resource.type === KUBERNETES_MANIFEST_TYPE;
+    }
+
+    /**
+     * Extract namespace from raw manifest YAML content.
+     * Looks for `namespace: <value>` under `metadata:`.
+     * Returns undefined if not found (e.g. cluster-scoped resources like ClusterIssuer).
+     */
+    private static extractNamespaceFromManifest(manifest: string | undefined): string | undefined {
+        if (!manifest) return undefined;
+        // Match `namespace: <value>` that appears after `metadata:` block
+        const match = manifest.match(/\bnamespace:\s*(\S+)/);
+        return match?.[1];
     }
 }

--- a/src/kubernetes/kubernetesNamespace.ts
+++ b/src/kubernetes/kubernetesNamespace.ts
@@ -3,6 +3,18 @@ import { resolveConfig } from '../common/paramResolver.js';
 
 export const KUBERNETES_NAMESPACE_TYPE = 'KubernetesNamespace';
 
+/**
+ * Returns a Command that idempotently ensures a K8s namespace exists.
+ * Uses `kubectl create namespace --dry-run=client -o yaml | kubectl apply -f -`
+ * which is safe to run repeatedly (no-op if namespace already exists).
+ */
+export function ensureNamespaceCommand(namespace: string): Command {
+    return {
+        command: 'bash',
+        args: ['-c', `kubectl create namespace ${namespace} --dry-run=client -o yaml | kubectl apply -f -`],
+    };
+}
+
 export interface KubernetesNamespaceConfig extends ResourceSchema {
     /** The namespace name. Defaults to resource.name if omitted. */
     namespaceName?: string;

--- a/src/kubernetes/kubernetesService.ts
+++ b/src/kubernetes/kubernetesService.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
-import { manifestToYaml } from './kubernetesNamespace.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_SERVICE_TYPE = 'KubernetesService';
 
@@ -54,7 +54,9 @@ export class KubernetesServiceRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {

--- a/src/kubernetes/kubernetesServiceAccount.ts
+++ b/src/kubernetes/kubernetesServiceAccount.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
 import { resolveConfig } from '../common/paramResolver.js';
-import { manifestToYaml } from './kubernetesNamespace.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
 
 export const KUBERNETES_SERVICE_ACCOUNT_TYPE = 'KubernetesServiceAccount';
 
@@ -34,7 +34,9 @@ export class KubernetesServiceAccountRender implements Render {
     async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
         const { resource: resolved, captureCommands } = await resolveConfig(resource);
         const renderCommands = await this.renderImpl(resolved, context);
-        return [...captureCommands, ...renderCommands];
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
     }
 
     async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {

--- a/src/kubernetes/test/kubernetes.test.ts
+++ b/src/kubernetes/test/kubernetes.test.ts
@@ -129,36 +129,37 @@ describe('KubernetesDeploymentRender', () => {
     it('renders kubectl apply with Deployment manifest', async () => {
         const resource = makeDeploymentResource();
         const commands = await render.render(resource);
-        expect(commands).toHaveLength(1);
-        expect(commands[0].command).toBe('kubectl');
-        expect(commands[0].fileContent).toContain('kind: Deployment');
-        expect(commands[0].fileContent).toContain('name: trinity-gateway');
-        expect(commands[0].fileContent).toContain('namespace: trinity');
+        expect(commands).toHaveLength(2);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
+        expect(commands[1].fileContent).toContain('kind: Deployment');
+        expect(commands[1].fileContent).toContain('name: trinity-gateway');
+        expect(commands[1].fileContent).toContain('namespace: trinity');
     });
 
     it('sets replicas in manifest', async () => {
         const resource = makeDeploymentResource({ replicas: 3 });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('replicas: 3');
+        expect(commands[1].fileContent).toContain('replicas: 3');
     });
 
     it('defaults replicas to 1', async () => {
         const resource = makeDeploymentResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('replicas: 1');
+        expect(commands[1].fileContent).toContain('replicas: 1');
     });
 
     it('includes container image', async () => {
         const resource = makeDeploymentResource();
         const commands = await render.render(resource);
         // URLs with colons/slashes get quoted in YAML
-        expect(commands[0].fileContent).toContain('ghcr.io/example/gateway:latest');
+        expect(commands[1].fileContent).toContain('ghcr.io/example/gateway:latest');
     });
 
     it('includes containerPort when port is set', async () => {
         const resource = makeDeploymentResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('containerPort: 3000');
+        expect(commands[1].fileContent).toContain('containerPort: 3000');
     });
 
     it('converts envVars KEY=VALUE strings to env entries', async () => {
@@ -170,10 +171,10 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('name: NODE_ENV');
-        expect(commands[0].fileContent).toContain('value: staging');
-        expect(commands[0].fileContent).toContain('name: PORT');
-        expect(commands[0].fileContent).toContain('value: "3000"');
+        expect(commands[1].fileContent).toContain('name: NODE_ENV');
+        expect(commands[1].fileContent).toContain('value: staging');
+        expect(commands[1].fileContent).toContain('name: PORT');
+        expect(commands[1].fileContent).toContain('value: "3000"');
     });
 
     it('includes resource requests/limits', async () => {
@@ -188,7 +189,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
         expect(yaml).toContain('cpu: 250m');
         expect(yaml).toContain('memory: 256Mi');
         expect(yaml).toContain('cpu: 500m');
@@ -208,23 +209,23 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('livenessProbe:');
-        expect(commands[0].fileContent).toContain('path: /health');
-        expect(commands[0].fileContent).toContain('periodSeconds: 10');
+        expect(commands[1].fileContent).toContain('livenessProbe:');
+        expect(commands[1].fileContent).toContain('path: /health');
+        expect(commands[1].fileContent).toContain('periodSeconds: 10');
     });
 
     it('includes imagePullSecrets when set', async () => {
         const resource = makeDeploymentResource({ imagePullSecrets: ['acr-secret'] });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('imagePullSecrets:');
-        expect(commands[0].fileContent).toContain('name: acr-secret');
+        expect(commands[1].fileContent).toContain('imagePullSecrets:');
+        expect(commands[1].fileContent).toContain('name: acr-secret');
     });
 
     it('sets correct selector matchLabels', async () => {
         const resource = makeDeploymentResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('matchLabels:');
-        expect(commands[0].fileContent).toContain('app: trinity-gateway');
+        expect(commands[1].fileContent).toContain('matchLabels:');
+        expect(commands[1].fileContent).toContain('app: trinity-gateway');
     });
 
     // ── envFrom ─────────────────────────────────────────────────────────────
@@ -238,9 +239,9 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('envFrom:');
-        expect(commands[0].fileContent).toContain('configMapRef:');
-        expect(commands[0].fileContent).toContain('name: trinity-shared-config');
+        expect(commands[1].fileContent).toContain('envFrom:');
+        expect(commands[1].fileContent).toContain('configMapRef:');
+        expect(commands[1].fileContent).toContain('name: trinity-shared-config');
     });
 
     it('renders envFrom with secretRef', async () => {
@@ -252,9 +253,9 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('envFrom:');
-        expect(commands[0].fileContent).toContain('secretRef:');
-        expect(commands[0].fileContent).toContain('name: trinity-shared-secrets');
+        expect(commands[1].fileContent).toContain('envFrom:');
+        expect(commands[1].fileContent).toContain('secretRef:');
+        expect(commands[1].fileContent).toContain('name: trinity-shared-secrets');
     });
 
     it('renders envFrom with both configMapRef and secretRef entries', async () => {
@@ -269,7 +270,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
         expect(yaml).toContain('configMapRef:');
         expect(yaml).toContain('secretRef:');
     });
@@ -283,7 +284,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('prefix: APP_');
+        expect(commands[1].fileContent).toContain('prefix: APP_');
     });
 
     it('envFrom appears before env in manifest', async () => {
@@ -296,7 +297,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
         const envFromIdx = yaml.indexOf('envFrom:');
         const envIdx = yaml.indexOf('env:');
         expect(envFromIdx).toBeGreaterThan(-1);
@@ -310,9 +311,9 @@ describe('KubernetesDeploymentRender', () => {
             podLabels: { 'azure.workload.identity/use': 'true' },
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('azure.workload.identity/use');
+        expect(commands[1].fileContent).toContain('azure.workload.identity/use');
         // "true" as string gets quoted
-        expect(commands[0].fileContent).toContain('"true"');
+        expect(commands[1].fileContent).toContain('"true"');
     });
 
     it('podLabels merge with default app/ring labels', async () => {
@@ -320,7 +321,7 @@ describe('KubernetesDeploymentRender', () => {
             podLabels: { custom: 'value' },
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
         expect(yaml).toContain('app: trinity-gateway');
         expect(yaml).toContain('ring: staging');
         expect(yaml).toContain('custom: value');
@@ -333,7 +334,7 @@ describe('KubernetesDeploymentRender', () => {
             serviceAccountName: 'trinity-workload-sa',
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('serviceAccountName: trinity-workload-sa');
+        expect(commands[1].fileContent).toContain('serviceAccountName: trinity-workload-sa');
     });
 
     // ── volumes ───────────────────────────────────────────────────────────────
@@ -352,7 +353,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
         expect(yaml).toContain('name: secrets-store');
         expect(yaml).toContain('driver: secrets-store.csi.k8s.io');
         expect(yaml).toContain('readOnly: true');
@@ -374,7 +375,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
         expect(yaml).toContain('volumeMounts:');
         expect(yaml).toContain('name: secrets-store');
         expect(yaml).toContain('mountPath: /mnt/secrets-store');
@@ -412,7 +413,7 @@ describe('KubernetesDeploymentRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        const yaml = commands[0].fileContent!;
+        const yaml = commands[1].fileContent!;
 
         // Pod-level
         expect(yaml).toContain('serviceAccountName: trinity-workload-sa');
@@ -457,42 +458,43 @@ describe('KubernetesServiceRender', () => {
     it('renders kubectl apply with Service manifest', async () => {
         const resource = makeServiceResource();
         const commands = await render.render(resource);
-        expect(commands).toHaveLength(1);
-        expect(commands[0].command).toBe('kubectl');
-        expect(commands[0].fileContent).toContain('kind: Service');
-        expect(commands[0].fileContent).toContain('name: trinity-gateway');
+        expect(commands).toHaveLength(2);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
+        expect(commands[1].fileContent).toContain('kind: Service');
+        expect(commands[1].fileContent).toContain('name: trinity-gateway');
     });
 
     it('defaults to ClusterIP', async () => {
         const resource = makeServiceResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('type: ClusterIP');
+        expect(commands[1].fileContent).toContain('type: ClusterIP');
     });
 
     it('sets LoadBalancer type when specified', async () => {
         const resource = makeServiceResource({ serviceType: 'LoadBalancer' });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('type: LoadBalancer');
+        expect(commands[1].fileContent).toContain('type: LoadBalancer');
     });
 
     it('adds azure internal LB annotation when internalLoadBalancer is true', async () => {
         const resource = makeServiceResource({ serviceType: 'LoadBalancer', internalLoadBalancer: true });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('service.beta.kubernetes.io/azure-load-balancer-internal');
-        expect(commands[0].fileContent).toContain('"true"');
+        expect(commands[1].fileContent).toContain('service.beta.kubernetes.io/azure-load-balancer-internal');
+        expect(commands[1].fileContent).toContain('"true"');
     });
 
     it('uses appName as selector shorthand', async () => {
         const resource = makeServiceResource({ appName: 'trinity-gateway' });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('app: trinity-gateway');
+        expect(commands[1].fileContent).toContain('app: trinity-gateway');
     });
 
     it('uses explicit selector over appName', async () => {
         const resource = makeServiceResource({ selector: { 'app.kubernetes.io/name': 'gateway' }, appName: 'ignored' });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('app.kubernetes.io/name');
-        expect(commands[0].fileContent).toContain('gateway');
+        expect(commands[1].fileContent).toContain('app.kubernetes.io/name');
+        expect(commands[1].fileContent).toContain('gateway');
     });
 });
 
@@ -533,32 +535,33 @@ describe('KubernetesIngressRender', () => {
     it('renders kubectl apply with Ingress manifest', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        expect(commands).toHaveLength(1);
-        expect(commands[0].command).toBe('kubectl');
-        expect(commands[0].fileContent).toContain('kind: Ingress');
-        expect(commands[0].fileContent).toContain('name: trinity-ingress');
-        expect(commands[0].fileContent).toContain('namespace: trinity');
+        expect(commands).toHaveLength(2);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
+        expect(commands[1].fileContent).toContain('kind: Ingress');
+        expect(commands[1].fileContent).toContain('name: trinity-ingress');
+        expect(commands[1].fileContent).toContain('namespace: trinity');
     });
 
     it('sets ingressClassName', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('ingressClassName: nginx');
+        expect(commands[1].fileContent).toContain('ingressClassName: nginx');
     });
 
     it('includes host and path rules', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('host: api.trinity.example.com');
-        expect(commands[0].fileContent).toContain('path: /');
-        expect(commands[0].fileContent).toContain('name: trinity-gateway');
+        expect(commands[1].fileContent).toContain('host: api.trinity.example.com');
+        expect(commands[1].fileContent).toContain('path: /');
+        expect(commands[1].fileContent).toContain('name: trinity-gateway');
     });
 
     it('adds cert-manager cluster-issuer annotation when clusterIssuer is set', async () => {
         const resource = makeIngressResource({ clusterIssuer: 'letsencrypt-prod' });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('cert-manager.io/cluster-issuer');
-        expect(commands[0].fileContent).toContain('letsencrypt-prod');
+        expect(commands[1].fileContent).toContain('cert-manager.io/cluster-issuer');
+        expect(commands[1].fileContent).toContain('letsencrypt-prod');
     });
 
     it('includes TLS section when tls is configured', async () => {
@@ -566,15 +569,15 @@ describe('KubernetesIngressRender', () => {
             tls: [{ hosts: ['api.trinity.example.com'], secretName: 'trinity-tls' }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('tls:');
-        expect(commands[0].fileContent).toContain('secretName: trinity-tls');
-        expect(commands[0].fileContent).toContain('api.trinity.example.com');
+        expect(commands[1].fileContent).toContain('tls:');
+        expect(commands[1].fileContent).toContain('secretName: trinity-tls');
+        expect(commands[1].fileContent).toContain('api.trinity.example.com');
     });
 
     it('uses networking.k8s.io/v1 apiVersion', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('apiVersion: networking.k8s.io/v1');
+        expect(commands[1].fileContent).toContain('apiVersion: networking.k8s.io/v1');
     });
 
     it('defaults pathType to Prefix when not specified', async () => {
@@ -585,6 +588,6 @@ describe('KubernetesIngressRender', () => {
             }],
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('pathType: Prefix');
+        expect(commands[1].fileContent).toContain('pathType: Prefix');
     });
 });

--- a/src/kubernetes/test/kubernetesCluster.test.ts
+++ b/src/kubernetes/test/kubernetesCluster.test.ts
@@ -201,13 +201,11 @@ describe('AzureAKSRender', () => {
             expect(credsCmd!.args).toContain('--overwrite-existing');
         });
 
-        it('emits kubectl create namespace for each configured namespace', async () => {
+        it('does not emit namespace commands (namespace creation moved to individual resource renders)', async () => {
             const resource = makeResource({ namespaces: ['trinity', 'alluneed'] });
             const commands = await render.render(resource);
-            const trinityCmds = commands.filter(c => c.command === 'bash' && c.args.some(a => a.includes('trinity')));
-            expect(trinityCmds).toHaveLength(1);
-            const alluneedCmds = commands.filter(c => c.command === 'bash' && c.args.some(a => a.includes('alluneed')));
-            expect(alluneedCmds).toHaveLength(1);
+            const nsCmds = commands.filter(c => c.command === 'bash' && c.args.some(a => a.includes('create namespace')));
+            expect(nsCmds).toHaveLength(0);
         });
 
         it('does not emit namespace commands when namespaces is empty', async () => {

--- a/src/kubernetes/test/kubernetesConfigMap.test.ts
+++ b/src/kubernetes/test/kubernetesConfigMap.test.ts
@@ -31,39 +31,40 @@ describe('KubernetesConfigMapRender', () => {
     it('renders kubectl apply with ConfigMap manifest', async () => {
         const resource = makeConfigMapResource();
         const commands = await render.render(resource);
-        expect(commands).toHaveLength(1);
-        expect(commands[0].command).toBe('kubectl');
-        expect(commands[0].args).toContain('apply');
-        expect(commands[0].args).toContain('__MERLIN_YAML_FILE__');
-        expect(commands[0].fileContent).toContain('kind: ConfigMap');
-        expect(commands[0].fileContent).toContain('name: trinity-shared-config');
-        expect(commands[0].fileContent).toContain('namespace: trinity');
+        expect(commands).toHaveLength(2);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
+        expect(commands[1].args).toContain('apply');
+        expect(commands[1].args).toContain('__MERLIN_YAML_FILE__');
+        expect(commands[1].fileContent).toContain('kind: ConfigMap');
+        expect(commands[1].fileContent).toContain('name: trinity-shared-config');
+        expect(commands[1].fileContent).toContain('namespace: trinity');
     });
 
     it('includes data key-value pairs', async () => {
         const resource = makeConfigMapResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('REDIS_URL');
-        expect(commands[0].fileContent).toContain('redis://redis.example.com:6380');
-        expect(commands[0].fileContent).toContain('ADMIN_SERVER_URL');
+        expect(commands[1].fileContent).toContain('REDIS_URL');
+        expect(commands[1].fileContent).toContain('redis://redis.example.com:6380');
+        expect(commands[1].fileContent).toContain('ADMIN_SERVER_URL');
     });
 
     it('uses apiVersion v1', async () => {
         const resource = makeConfigMapResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('apiVersion: v1');
+        expect(commands[1].fileContent).toContain('apiVersion: v1');
     });
 
     it('includes labels when configured', async () => {
         const resource = makeConfigMapResource({ labels: { team: 'platform' } });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('team: platform');
+        expect(commands[1].fileContent).toContain('team: platform');
     });
 
     it('includes annotations when configured', async () => {
         const resource = makeConfigMapResource({ annotations: { owner: 'merlin' } });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('owner: merlin');
+        expect(commands[1].fileContent).toContain('owner: merlin');
     });
 
     it('throws for wrong resource type', async () => {

--- a/src/kubernetes/test/kubernetesHelmRelease.test.ts
+++ b/src/kubernetes/test/kubernetesHelmRelease.test.ts
@@ -31,19 +31,20 @@ describe('KubernetesHelmReleaseRender', () => {
 
     it('emits helm repo add as first command', async () => {
         const commands = await render.render(makeResource());
-        expect(commands[0].command).toBe('helm');
-        expect(commands[0].args).toEqual(['repo', 'add', 'ingress-nginx', 'https://kubernetes.github.io/ingress-nginx']);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('helm');
+        expect(commands[1].args).toEqual(['repo', 'add', 'ingress-nginx', 'https://kubernetes.github.io/ingress-nginx']);
     });
 
     it('emits helm repo update as second command', async () => {
         const commands = await render.render(makeResource());
-        expect(commands[1].command).toBe('helm');
-        expect(commands[1].args).toEqual(['repo', 'update']);
+        expect(commands[2].command).toBe('helm');
+        expect(commands[2].args).toEqual(['repo', 'update']);
     });
 
     it('emits helm upgrade --install as third command', async () => {
         const commands = await render.render(makeResource());
-        const installCmd = commands[2];
+        const installCmd = commands[3];
         expect(installCmd.command).toBe('helm');
         expect(installCmd.args[0]).toBe('upgrade');
         expect(installCmd.args[1]).toBe('--install');
@@ -53,7 +54,7 @@ describe('KubernetesHelmReleaseRender', () => {
 
     it('includes --namespace', async () => {
         const commands = await render.render(makeResource());
-        const args = commands[2].args;
+        const args = commands[3].args;
         const idx = args.indexOf('--namespace');
         expect(idx).toBeGreaterThan(-1);
         expect(args[idx + 1]).toBe('ingress-nginx');
@@ -61,17 +62,17 @@ describe('KubernetesHelmReleaseRender', () => {
 
     it('includes --create-namespace by default', async () => {
         const commands = await render.render(makeResource());
-        expect(commands[2].args).toContain('--create-namespace');
+        expect(commands[3].args).toContain('--create-namespace');
     });
 
     it('omits --create-namespace when createNamespace is false', async () => {
         const commands = await render.render(makeResource({ createNamespace: false }));
-        expect(commands[2].args).not.toContain('--create-namespace');
+        expect(commands[3].args).not.toContain('--create-namespace');
     });
 
     it('includes --version when set', async () => {
         const commands = await render.render(makeResource({ version: '4.10.0' }));
-        const args = commands[2].args;
+        const args = commands[3].args;
         const idx = args.indexOf('--version');
         expect(idx).toBeGreaterThan(-1);
         expect(args[idx + 1]).toBe('4.10.0');
@@ -79,7 +80,7 @@ describe('KubernetesHelmReleaseRender', () => {
 
     it('omits --version when not set', async () => {
         const commands = await render.render(makeResource());
-        expect(commands[2].args).not.toContain('--version');
+        expect(commands[3].args).not.toContain('--version');
     });
 
     it('includes --set key=value pairs', async () => {
@@ -89,7 +90,7 @@ describe('KubernetesHelmReleaseRender', () => {
                 { key: 'controller.service.type', value: 'LoadBalancer' },
             ],
         }));
-        const args = commands[2].args;
+        const args = commands[3].args;
         expect(args).toContain('--set');
         expect(args).toContain('controller.replicaCount=2');
         expect(args).toContain('controller.service.type=LoadBalancer');
@@ -99,31 +100,31 @@ describe('KubernetesHelmReleaseRender', () => {
         const commands = await render.render(makeResource({
             setString: [{ key: 'controller.image.tag', value: 'v1.9.0' }],
         }));
-        const args = commands[2].args;
+        const args = commands[3].args;
         expect(args).toContain('--set-string');
         expect(args).toContain('controller.image.tag=v1.9.0');
     });
 
     it('includes --wait when wait is true', async () => {
         const commands = await render.render(makeResource({ wait: true }));
-        expect(commands[2].args).toContain('--wait');
+        expect(commands[3].args).toContain('--wait');
     });
 
     it('includes --timeout when wait and timeout are set', async () => {
         const commands = await render.render(makeResource({ wait: true, timeout: '5m0s' }));
-        const args = commands[2].args;
+        const args = commands[3].args;
         expect(args).toContain('--timeout');
         expect(args[args.indexOf('--timeout') + 1]).toBe('5m0s');
     });
 
     it('omits --timeout when wait is false', async () => {
         const commands = await render.render(makeResource({ wait: false, timeout: '5m0s' }));
-        expect(commands[2].args).not.toContain('--timeout');
+        expect(commands[3].args).not.toContain('--timeout');
     });
 
-    it('always produces exactly 3 commands (repo add, repo update, upgrade)', async () => {
+    it('always produces exactly 4 commands (namespace ensure, repo add, repo update, upgrade)', async () => {
         const commands = await render.render(makeResource());
-        expect(commands).toHaveLength(3);
+        expect(commands).toHaveLength(4);
     });
 
     it('includes --values with fileContent when values object is provided', async () => {
@@ -138,7 +139,7 @@ describe('KubernetesHelmReleaseRender', () => {
                 },
             },
         }));
-        const installCmd = commands[2];
+        const installCmd = commands[3];
         expect(installCmd.args).toContain('--values');
         expect(installCmd.args).toContain('__MERLIN_YAML_FILE__');
         expect(installCmd.fileContent).toBeDefined();
@@ -148,14 +149,14 @@ describe('KubernetesHelmReleaseRender', () => {
 
     it('omits --values when values is empty object', async () => {
         const commands = await render.render(makeResource({ values: {} }));
-        const installCmd = commands[2];
+        const installCmd = commands[3];
         expect(installCmd.args).not.toContain('--values');
         expect(installCmd.fileContent).toBeUndefined();
     });
 
     it('omits --values when values is not set', async () => {
         const commands = await render.render(makeResource());
-        const installCmd = commands[2];
+        const installCmd = commands[3];
         expect(installCmd.args).not.toContain('--values');
         expect(installCmd.fileContent).toBeUndefined();
     });

--- a/src/kubernetes/test/kubernetesIngress.test.ts
+++ b/src/kubernetes/test/kubernetesIngress.test.ts
@@ -44,17 +44,18 @@ describe('KubernetesIngressRender', () => {
     it('renders kubectl apply with Ingress manifest', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        expect(commands[0].command).toBe('kubectl');
-        expect(commands[0].args).toContain('apply');
-        expect(commands[0].fileContent).toContain('kind: Ingress');
-        expect(commands[0].fileContent).toContain('name: trinity-web');
-        expect(commands[0].fileContent).toContain('namespace: trinity');
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
+        expect(commands[1].args).toContain('apply');
+        expect(commands[1].fileContent).toContain('kind: Ingress');
+        expect(commands[1].fileContent).toContain('name: trinity-web');
+        expect(commands[1].fileContent).toContain('namespace: trinity');
     });
 
     it('includes cert-manager annotation when clusterIssuer is set', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('cert-manager.io/cluster-issuer: letsencrypt-prod');
+        expect(commands[1].fileContent).toContain('cert-manager.io/cluster-issuer: letsencrypt-prod');
     });
 
     it('throws for wrong resource type', async () => {
@@ -68,9 +69,10 @@ describe('KubernetesIngressRender', () => {
     it('does not generate DNS commands when bindDnsZone is not configured', async () => {
         const resource = makeIngressResource();
         const commands = await render.render(resource);
-        // Only the kubectl apply command
-        expect(commands).toHaveLength(1);
-        expect(commands[0].command).toBe('kubectl');
+        // 1 namespace ensure + 1 kubectl apply command
+        expect(commands).toHaveLength(2);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
     });
 
     it('generates DNS commands when bindDnsZone is configured', async () => {
@@ -79,31 +81,34 @@ describe('KubernetesIngressRender', () => {
         });
         const commands = await render.render(resource);
 
-        // 1 kubectl apply + 1 LB IP capture + 1 DNS zone RG capture + 1 A record = 4
-        expect(commands).toHaveLength(4);
+        // 1 namespace ensure + 1 kubectl apply + 1 LB IP capture + 1 DNS zone RG capture + 1 A record = 5
+        expect(commands).toHaveLength(5);
 
-        // Command 0: kubectl apply
-        expect(commands[0].command).toBe('kubectl');
+        // Command 0: namespace ensure (bash)
+        expect(commands[0].command).toBe('bash');
 
-        // Command 1: capture LB IP
+        // Command 1: kubectl apply
         expect(commands[1].command).toBe('kubectl');
-        expect(commands[1].args).toContain('get');
-        expect(commands[1].args).toContain('svc');
-        expect(commands[1].args).toContain('ingress-nginx-controller');
-        expect(commands[1].args).toContain('-n');
-        expect(commands[1].args).toContain('ingress-nginx');
-        expect(commands[1].envCapture).toContain('LB_IP');
 
-        // Command 2: capture DNS zone RG
-        expect(commands[2].command).toBe('az');
-        expect(commands[2].args).toContain('dns');
-        expect(commands[2].args).toContain('zone');
-        expect(commands[2].args).toContain('list');
-        expect(commands[2].envCapture).toContain('DNS_ZONE_RG');
+        // Command 2: capture LB IP
+        expect(commands[2].command).toBe('kubectl');
+        expect(commands[2].args).toContain('get');
+        expect(commands[2].args).toContain('svc');
+        expect(commands[2].args).toContain('ingress-nginx-controller');
+        expect(commands[2].args).toContain('-n');
+        expect(commands[2].args).toContain('ingress-nginx');
+        expect(commands[2].envCapture).toContain('LB_IP');
 
-        // Command 3: create A record
-        expect(commands[3].command).toBe('bash');
-        const bashCmd = commands[3].args[1];
+        // Command 3: capture DNS zone RG
+        expect(commands[3].command).toBe('az');
+        expect(commands[3].args).toContain('dns');
+        expect(commands[3].args).toContain('zone');
+        expect(commands[3].args).toContain('list');
+        expect(commands[3].envCapture).toContain('DNS_ZONE_RG');
+
+        // Command 4: create A record
+        expect(commands[4].command).toBe('bash');
+        const bashCmd = commands[4].args[1];
         expect(bashCmd).toContain('add-record');
         expect(bashCmd).toContain('web.staging');
         expect(bashCmd).toContain('thebrainly.dev');
@@ -125,11 +130,11 @@ describe('KubernetesIngressRender', () => {
         });
         const commands = await render.render(resource);
 
-        // 1 kubectl + 1 LB IP + 1 DNS RG + 2 A records = 5
-        expect(commands).toHaveLength(5);
+        // 1 namespace ensure + 1 kubectl + 1 LB IP + 1 DNS RG + 2 A records = 6
+        expect(commands).toHaveLength(6);
 
-        // Two bash commands for DNS records
-        const dnsCommands = commands.filter(c => c.command === 'bash');
+        // Two bash commands for DNS records (skip commands[0] which is namespace ensure)
+        const dnsCommands = commands.filter((c, i) => i > 0 && c.command === 'bash');
         expect(dnsCommands).toHaveLength(2);
         expect(dnsCommands[0].args[1]).toContain('web.staging');
         expect(dnsCommands[1].args[1]).toContain('api.staging');
@@ -151,8 +156,8 @@ describe('KubernetesIngressRender', () => {
         });
         const commands = await render.render(resource);
 
-        // 1 kubectl + 1 LB IP + 1 DNS RG + 1 A record (deduplicated) = 4
-        expect(commands).toHaveLength(4);
+        // 1 namespace ensure + 1 kubectl + 1 LB IP + 1 DNS RG + 1 A record (deduplicated) = 5
+        expect(commands).toHaveLength(5);
     });
 
     it('throws when host does not end with dnsZone', async () => {
@@ -179,7 +184,7 @@ describe('KubernetesIngressRender', () => {
         const commands = await render.render(resource);
 
         // LB IP capture command should use custom service name/namespace
-        expect(commands[1].args).toContain('my-nginx');
-        expect(commands[1].args).toContain('custom-ns');
+        expect(commands[2].args).toContain('my-nginx');
+        expect(commands[2].args).toContain('custom-ns');
     });
 });

--- a/src/kubernetes/test/kubernetesServiceAccount.test.ts
+++ b/src/kubernetes/test/kubernetesServiceAccount.test.ts
@@ -27,19 +27,20 @@ describe('KubernetesServiceAccountRender', () => {
     it('renders kubectl apply with ServiceAccount manifest', async () => {
         const resource = makeSAResource();
         const commands = await render.render(resource);
-        expect(commands).toHaveLength(1);
-        expect(commands[0].command).toBe('kubectl');
-        expect(commands[0].args).toContain('apply');
-        expect(commands[0].args).toContain('__MERLIN_YAML_FILE__');
-        expect(commands[0].fileContent).toContain('kind: ServiceAccount');
-        expect(commands[0].fileContent).toContain('name: trinity-workload-sa');
-        expect(commands[0].fileContent).toContain('namespace: trinity');
+        expect(commands).toHaveLength(2);
+        expect(commands[0].command).toBe('bash');
+        expect(commands[1].command).toBe('kubectl');
+        expect(commands[1].args).toContain('apply');
+        expect(commands[1].args).toContain('__MERLIN_YAML_FILE__');
+        expect(commands[1].fileContent).toContain('kind: ServiceAccount');
+        expect(commands[1].fileContent).toContain('name: trinity-workload-sa');
+        expect(commands[1].fileContent).toContain('namespace: trinity');
     });
 
     it('uses apiVersion v1', async () => {
         const resource = makeSAResource();
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('apiVersion: v1');
+        expect(commands[1].fileContent).toContain('apiVersion: v1');
     });
 
     it('includes annotations when configured', async () => {
@@ -49,14 +50,14 @@ describe('KubernetesServiceAccountRender', () => {
             },
         });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('azure.workload.identity/client-id');
-        expect(commands[0].fileContent).toContain('test-client-id-12345');
+        expect(commands[1].fileContent).toContain('azure.workload.identity/client-id');
+        expect(commands[1].fileContent).toContain('test-client-id-12345');
     });
 
     it('includes labels when configured', async () => {
         const resource = makeSAResource({ labels: { team: 'platform' } });
         const commands = await render.render(resource);
-        expect(commands[0].fileContent).toContain('team: platform');
+        expect(commands[1].fileContent).toContain('team: platform');
     });
 
     it('throws for wrong resource type', async () => {


### PR DESCRIPTION
## Summary

- Each K8s render now auto-runs `kubectl create namespace` before applying resources
- Removes hardcoded `namespaces: [synapse, trinity, alluneed]` from `sharedaks.yml`
- New projects no longer need to edit shared AKS config — just set `namespace: myapp` in resource YAML

## Test plan

- [x] `pnpm build` passes
- [x] All 861 K8s-related tests pass (28 test files)
- [x] Pre-existing compiler/integration timeout failures (26 tests) are unaffected
- [ ] Deploy dry-run shows namespace ensure commands before each kubectl apply

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)