### PR TITLE
feat: unified shared ACR and optional ring for global resources

### DIFF
--- a/alluneed-k8s-resource/alluneeddeployment.yml
+++ b/alluneed-k8s-resource/alluneeddeployment.yml
@@ -23,7 +23,7 @@ defaultConfig:
 
   containers:
     - name: alluneed
-      image: brainlysharedstgkrcacr.azurecr.io/alluneed:latest
+      image: brainlysharedacr.azurecr.io/alluneed:latest
       imagePullPolicy: IfNotPresent
       port: 8000
       cpuRequest: "1000m"

--- a/shared-k8s-resource/sharedaks.yml
+++ b/shared-k8s-resource/sharedaks.yml
@@ -8,9 +8,7 @@ region:
   - koreacentral
   - eastasia
 
-dependencies:
-  - resource: AzureContainerRegistry.shared
-    isHardDependency: true
+dependencies: []
 
 defaultConfig:
   enableManagedIdentity: true
@@ -18,7 +16,7 @@ defaultConfig:
   enableWorkloadIdentity: true
   enableCsiSecretProvider: true
   enableSecretRotation: true
-  attachAcr: ${ AzureContainerRegistry.shared.name }
+  attachAcr: brainlysharedacr
   nodeVmSize: Standard_D2s_v3
   nodeCount: 2
   enableAutoScaling: true

--- a/shared-resource/sharedacr.yml
+++ b/shared-resource/sharedacr.yml
@@ -1,12 +1,7 @@
 name: shared
 type: AzureContainerRegistry
 project: brainly
-ring:
-  - test
-  - staging
-region:
-  - koreacentral
-  - eastasia
+# No ring/region — ACR is a global shared resource across all environments
 
 authProvider:
   name: AzureManagedIdentity
@@ -16,12 +11,14 @@ authProvider:
 dependencies: []
 
 defaultConfig:
+  resourceName: brainlysharedacr
+  resourceGroupName: brainly-rg-shared
+  location: koreacentral
   sku: Basic
   adminUserEnabled: false
 
   tags:
     merlin: "true"
-    env: ${ this.ring }
 
 specificConfig: []
 

--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -8,9 +8,7 @@ ring:
 authProvider:
   name: AzureEntraID
 
-dependencies:
-  - resource: AzureContainerRegistry.shared
-    isHardDependency: true
+dependencies: []
 
 defaultConfig:
   tags:
@@ -38,12 +36,9 @@ specificConfig:
       # Alluneed RG — eastasia
       - role: Container Apps Contributor
         scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
-      # ACR — koreacentral
+      # ACR — shared (brainlysharedacr, used by all rings)
       - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc/providers/Microsoft.ContainerRegistry/registries/brainlysharedtstkrcacr
-      # ACR — eastasia
-      - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas/providers/Microsoft.ContainerRegistry/registries/brainlysharedtsteasacr
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-shared/providers/Microsoft.ContainerRegistry/registries/brainlysharedacr
       # AKS — kubectl access for K8s deploys (shared RG)
       - role: Azure Kubernetes Service Cluster User Role
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-krc
@@ -75,12 +70,9 @@ specificConfig:
       # Alluneed RG — eastasia
       - role: Container Apps Contributor
         scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
-      # ACR — koreacentral
+      # ACR — shared (brainlysharedacr, used by all rings)
       - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc/providers/Microsoft.ContainerRegistry/registries/brainlysharedstgkrcacr
-      # ACR — eastasia
-      - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas/providers/Microsoft.ContainerRegistry/registries/brainlysharedstgeasacr
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-shared/providers/Microsoft.ContainerRegistry/registries/brainlysharedacr
       # AKS — kubectl access for K8s deploys (shared RG)
       - role: Azure Kubernetes Service Cluster User Role
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-krc

--- a/src/azure/azureContainerRegistry.ts
+++ b/src/azure/azureContainerRegistry.ts
@@ -178,7 +178,6 @@ export class AzureContainerRegistryRender extends AzureResourceRender {
      */
     private static readonly SIMPLE_PARAM_MAP: Record<string, string> = {
         'sku': '--sku',
-        'location': '--location',
         'defaultAction': '--default-action',
         'dnlScope': '--dnl-scope',
         'identity': '--identity',
@@ -186,6 +185,13 @@ export class AzureContainerRegistryRender extends AzureResourceRender {
         'roleAssignmentMode': '--role-assignment-mode',
         'workspace': '--workspace',
         'zoneRedundancy': '--zone-redundancy',
+    };
+
+    /**
+     * Parameters only valid for create (not update)
+     */
+    private static readonly CREATE_ONLY_SIMPLE_PARAM_MAP: Record<string, string> = {
+        'location': '--location',
     };
 
     /**
@@ -221,6 +227,7 @@ export class AzureContainerRegistryRender extends AzureResourceRender {
 
         // Add all optional parameters using helper methods (only added if present in config)
         this.addSimpleParams(args, config, AzureContainerRegistryRender.SIMPLE_PARAM_MAP);
+        this.addSimpleParams(args, config, AzureContainerRegistryRender.CREATE_ONLY_SIMPLE_PARAM_MAP);
         this.addBooleanFlags(args, config, AzureContainerRegistryRender.BOOLEAN_FLAG_MAP);
         this.addTags(args, config.tags);
 

--- a/src/azure/render.ts
+++ b/src/azure/render.ts
@@ -52,6 +52,11 @@ export abstract class AzureResourceRender implements Render {
     }
 
     getResourceGroupName(resource: Resource): string {
+        // Allow config-level override
+        const config = resource.config as Record<string, unknown>;
+        if (config?.resourceGroupName && typeof config.resourceGroupName === 'string') {
+            return config.resourceGroupName;
+        }
         // [${project}-|shared]-rg-${ring}[-${region}]
         const projectPart = resource.project ? `${resource.project}` : 'shared';
         const ringPart = `rg-${RING_SHORT_NAME_MAP[resource.ring] || resource.ring}`;
@@ -60,6 +65,11 @@ export abstract class AzureResourceRender implements Render {
     }
 
     getResourceName(resource: Resource): string {
+        // Allow config-level override
+        const config = resource.config as Record<string, unknown>;
+        if (config?.resourceName && typeof config.resourceName === 'string') {
+            return config.resourceName;
+        }
         // [${project}-|shared]-${name}-${ring}[-${region}][-${type}]
         const projectPart = resource.project ? `${resource.project}` : 'shared';
         const ringPart = `${RING_SHORT_NAME_MAP[resource.ring] || resource.ring}`;

--- a/src/azure/resourceGroup.ts
+++ b/src/azure/resourceGroup.ts
@@ -74,15 +74,15 @@ export class AzureResourceGroupRender extends AzureResourceRender {
     }
 
     private renderCreate(resource: Resource): Command[] {
-        if (!resource.region) {
-            throw new Error(`Region is required for creating resource group for resource ${resource.name}`);
-        }
+        // Determine location: resource.region, or config.location, or default to koreacentral
+        const config = resource.config as Record<string, unknown>;
+        const location = resource.region ?? config?.location as string ?? 'koreacentral';
 
         const resourceGroupName = this.getResourceGroupName(resource);
         const args: string[] = [
             'group', 'create',
             '--name', resourceGroupName,
-            '--location', resource.region
+            '--location', location
         ];
 
         // Add tags if provided in config

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -66,7 +66,7 @@ dependencies:
 
 defaultConfig:
   namespace: ${project}
-  image: brainlysharedstgkrcacr.azurecr.io/${project}:latest  # TODO: Change to your image
+  image: brainlysharedacr.azurecr.io/${project}:latest  # TODO: Change to your image
   port: 3000  # TODO: Change to your port
   serviceAccountName: ${project}-workload-sa
   secretProvider: ${project}-secret-provider

--- a/src/common/compiler.ts
+++ b/src/common/compiler.ts
@@ -205,12 +205,12 @@ export class Compiler {
         const merged = this.mergeBySource(expandedResources);
         let allResources = merged.flatMap(m => m.resources);
 
-        // 6. Filter by ring/region
+        // 6. Filter by ring/region (resources with no ring/region are global — always included)
         if (options.ring) {
-            allResources = allResources.filter(r => r.ring === options.ring);
+            allResources = allResources.filter(r => r.ring === undefined || r.ring === options.ring);
         }
         if (options.region) {
-            allResources = allResources.filter(r => r.region === options.region);
+            allResources = allResources.filter(r => r.region === undefined || r.region === options.region);
         }
 
         return allResources;

--- a/src/common/paramResolver.ts
+++ b/src/common/paramResolver.ts
@@ -115,7 +115,7 @@ async function resolveSegment(
             return seg.value;
 
         case 'self':
-            if (seg.field === 'ring') return resource.ring;
+            if (seg.field === 'ring') return resource.ring ?? '';
             if (seg.field === 'region') return resource.region ?? '';
             // TypeScript exhaustiveness — should never happen
             throw new Error(`Unknown self field: ${(seg as { field: string }).field}`);
@@ -126,7 +126,8 @@ async function resolveSegment(
             if (!depResource) {
                 throw new Error(
                     `Cannot resolve parameter "\${ ${seg.resourceType}.${seg.resource}.${seg.export} }": ` +
-                    `no resource "${seg.resourceType}.${seg.resource}" registered for ring="${resource.ring}"` +
+                    `no resource "${seg.resourceType}.${seg.resource}" registered` +
+                    (resource.ring ? ` for ring="${resource.ring}"` : '') +
                     (resource.region ? `, region="${resource.region}"` : '')
                 );
             }
@@ -183,7 +184,7 @@ function toVarName(
     resourceType: string,
     resource: string,
     exportName: string,
-    ring: string,
+    ring?: string,
     region?: string
 ): string {
     const slug = (s: string) => s.toUpperCase().replace(/[^A-Z0-9]/g, '_');
@@ -196,7 +197,9 @@ function toVarName(
         shortType = resourceType; // fallback to full type name
     }
 
-    const shortRing = RING_SHORT_NAME_MAP[ring as keyof typeof RING_SHORT_NAME_MAP] ?? ring;
+    const shortRing = ring
+        ? RING_SHORT_NAME_MAP[ring as keyof typeof RING_SHORT_NAME_MAP] ?? ring
+        : undefined;
     const shortRegion = region
         ? REGION_SHORT_NAME_MAP[region as keyof typeof REGION_SHORT_NAME_MAP] ?? region
         : undefined;
@@ -205,8 +208,8 @@ function toVarName(
         'MERLIN',
         slug(shortType),
         slug(resource),
-        slug(shortRing),
     ];
+    if (shortRing) parts.push(slug(shortRing));
     if (shortRegion) parts.push(slug(shortRegion));
     parts.push(slug(exportName));
     return parts.join('_');

--- a/src/common/registry.ts
+++ b/src/common/registry.ts
@@ -36,35 +36,51 @@ export function registerResource(resource: Resource): void {
 
 /**
  * Gets a resource by type, name, ring, and optional region.
- * If the resource is registered as a global resource (isGlobalResource = true),
- * the region is ignored and the lookup falls back to the ring-only key.
  *
- * When the caller has no region (e.g. a global SP referencing a regional AKS),
- * falls back to any resource matching type:name:ring regardless of region.
+ * Lookup strategy (tries in order until a match is found):
+ * 1. Exact match: type:name:ring:region
+ * 2. Global resource (no region): type:name:ring (if resource.isGlobalResource)
+ * 3. Ring-less resource: type:name (for resources with no ring, e.g. shared ACR)
+ * 4. If caller has no region, scan for any type:name:ring:* match
+ * 5. If caller has no ring, scan for any type:name:*[:*] match
  */
 export function getResource(
     type: string,
     name: string,
-    ring: string,
+    ring?: string,
     region?: string
 ): Resource | undefined {
-    // First try exact match (with region)
+    // 1. Exact match (with ring and region)
     const exactKey = makeResourceKey(type, name, ring, region);
     const exact = RESOURCE_REGISTRY.get(exactKey);
     if (exact) return exact;
 
-    // If region was provided, also try the global (region-less) key
-    if (region) {
+    // 2. If region was provided, try global (region-less) key with same ring
+    if (region && ring) {
         const globalKey = makeResourceKey(type, name, ring, undefined);
         const global = RESOURCE_REGISTRY.get(globalKey);
         if (global?.isGlobalResource) return global;
     }
 
-    // If no region was provided (caller is a global resource), try to find
+    // 3. Try ring-less key (for resources that have no ring at all)
+    if (ring) {
+        const ringlessKey = makeResourceKey(type, name, undefined, undefined);
+        const ringless = RESOURCE_REGISTRY.get(ringlessKey);
+        if (ringless) return ringless;
+    }
+
+    // 4. If no region was provided (caller is a global resource), try to find
     // any regional resource matching type:name:ring:* (pick the first match).
-    // This allows global resources (e.g. SP) to reference regional resources (e.g. AKS).
-    if (!region) {
+    if (ring && !region) {
         const prefix = `${type}:${name}:${ring}:`;
+        for (const [key, res] of RESOURCE_REGISTRY) {
+            if (key.startsWith(prefix)) return res;
+        }
+    }
+
+    // 5. If no ring was provided, scan for any matching type:name:*
+    if (!ring) {
+        const prefix = `${type}:${name}:`;
         for (const [key, res] of RESOURCE_REGISTRY) {
             if (key.startsWith(prefix)) return res;
         }
@@ -89,8 +105,10 @@ export function clearRegistry(): void {
 
 /**
  * Creates a unique key for a resource.
- * Format: type:name:ring[:region]
+ * Format: type:name[:ring[:region]]
  */
-export function makeResourceKey(type: string, name: string, ring: string, region?: string): string {
-    return region ? `${type}:${name}:${ring}:${region}` : `${type}:${name}:${ring}`;
+export function makeResourceKey(type: string, name: string, ring?: string, region?: string): string {
+    if (ring && region) return `${type}:${name}:${ring}:${region}`;
+    if (ring) return `${type}:${name}:${ring}`;
+    return `${type}:${name}`;
 }

--- a/src/common/resource.ts
+++ b/src/common/resource.ts
@@ -100,8 +100,9 @@ export interface Resource<Schema extends ResourceSchema = ResourceSchema> {
 
     /**
      * The ring this resource belongs to, e.g. test, staging, production.
+     * undefined means the resource is not ring specific (shared across all rings).
      */
-    ring: Ring;
+    ring?: Ring;
 
     /**
      * The region this resource is deployed to, e.g. eastus, westus.

--- a/src/compiler/generator.ts
+++ b/src/compiler/generator.ts
@@ -76,9 +76,14 @@ import { Resource, getAuthProvider, getProprietyGetter, registerResource } from 
  * Generates the resource variable name
  */
 function generateResourceName(resource: ExpandedResource): string {
-    // With region: type_name_ring_region
-    // Without region: type_name_ring
-    const parts = [resource.type, resource.name, resource.ring];
+    // With ring+region: type_name_ring_region
+    // With ring only: type_name_ring
+    // No ring, with region: type_name_region
+    // No ring, no region: type_name
+    const parts = [resource.type, resource.name];
+    if (resource.ring) {
+        parts.push(resource.ring);
+    }
     if (resource.region) {
         parts.push(resource.region);
     }
@@ -93,7 +98,10 @@ function generateResourceObject(resource: ExpandedResource): string {
 
     // Basic fields
     code += `  name: ${JSON.stringify(resource.name)},\n`;
-    code += `  ring: ${JSON.stringify(resource.ring)},\n`;
+
+    if (resource.ring) {
+        code += `  ring: ${JSON.stringify(resource.ring)},\n`;
+    }
 
     if (resource.region) {
         code += `  region: ${JSON.stringify(resource.region)},\n`;

--- a/src/compiler/test/validator.test.ts
+++ b/src/compiler/test/validator.test.ts
@@ -43,14 +43,13 @@ describe('Validator', () => {
                 expect(result.errors.some(e => e.path === 'type')).toBe(true);
             });
 
-            test('should reject resource missing ring', () => {
+            test('should accept resource missing ring (global resource)', () => {
                 const data = { ...createResourceYAML(), ring: undefined };
                 const parsed = createParsedYAML(data);
 
                 const result = validate(parsed);
 
-                expect(result.valid).toBe(false);
-                expect(result.errors.some(e => e.path === 'ring')).toBe(true);
+                expect(result.valid).toBe(true);
             });
 
             test('should accept resource missing authProvider', () => {

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -11,8 +11,10 @@ import { parseConfigParams } from './interpolation.js';
  * and merges configuration overrides
  */
 export function expand(resource: ResourceYAML): ExpandedResource[] {
-    // Normalize to arrays
-    const rings: Ring[] = Array.isArray(resource.ring) ? resource.ring : [resource.ring];
+    // Normalize to arrays; undefined ring means one instance with no ring
+    const rings: (Ring | undefined)[] = resource.ring
+        ? (Array.isArray(resource.ring) ? resource.ring : [resource.ring])
+        : [undefined];
     // 'none' is an explicit opt-out from region expansion (for global resources)
     const regions: (Region | undefined)[] = (!resource.region || resource.region === 'none')
         ? [undefined]

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -77,7 +77,7 @@ export interface ValidationResult {
  */
 export interface ExpandedResource {
     name: string;
-    ring: Ring;              // Single value
+    ring?: Ring;              // Single value or undefined (global resource)
     region?: Region;         // Single value or undefined
     type: string;
     project?: string;

--- a/src/compiler/validator.ts
+++ b/src/compiler/validator.ts
@@ -55,23 +55,10 @@ export function validate(parsed: ParsedYAML): ValidationResult {
 function performSemanticValidation(data: any, source: string): CompilationError[] {
     const errors: CompilationError[] = [];
 
-    // ring is required for resource expansion — must be present after project defaults are applied
-    if (!data.ring) {
-        errors.push({
-            severity: ErrorSeverity.ERROR,
-            message: 'Resource must have a "ring" field (either directly or inherited from merlin.yml)',
-            source,
-            path: 'ring',
-            hint: 'Add ring: [test, staging] to this resource, or create a merlin.yml in the same directory with a ring field'
-        });
-        return errors; // Can't continue without ring
-    }
-
-    // Note: We'll check authProvider registration at runtime rather than compile-time
-    // This allows for flexible plugin loading and avoids circular dependencies
-
     // Validate specificConfig rings/regions match declared rings/regions
-    const declaredRings = Array.isArray(data.ring) ? data.ring : [data.ring];
+    const declaredRings = data.ring
+        ? (Array.isArray(data.ring) ? data.ring : [data.ring])
+        : [];
     const declaredRegions = (data.region && data.region !== 'none')
         ? (Array.isArray(data.region) ? data.region : [data.region])
         : [];
@@ -79,7 +66,7 @@ function performSemanticValidation(data: any, source: string): CompilationError[
     for (let i = 0; i < data.specificConfig.length; i++) {
         const spec = data.specificConfig[i];
 
-        if (spec.ring && !declaredRings.includes(spec.ring)) {
+        if (spec.ring && declaredRings.length > 0 && !declaredRings.includes(spec.ring)) {
             errors.push({
                 severity: ErrorSeverity.ERROR,
                 message: `specificConfig[${i}] references ring '${spec.ring}' which is not in the declared rings`,

--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -8,7 +8,7 @@
  *   3. Resource groups are deduplicated and deployed as level 0
  */
 
-import { Resource, Command, RenderContext } from './common/resource.js';
+import { Resource, Command, RenderContext, Region } from './common/resource.js';
 import { getAllResources, getResource } from './common/registry.js';
 import { getRender } from './common/resource.js';
 import { AzureResourceGroupRender } from './azure/resourceGroup.js';
@@ -274,26 +274,27 @@ export class Deployer {
     const seen = new Map<string, ResourceCommands>(); // rgName → commands
 
     for (const r of resources) {
-      // Skip resources that don't have a region (global resources handle RG differently)
-      // DNS zones use their own ensureResourceGroupCommandsForDnsZone which is also context-aware
-      if (!r.region) continue;
+      const config = r.config as Record<string, unknown>;
+      const hasCustomRG = config?.resourceGroupName && typeof config.resourceGroupName === 'string';
+
+      // Skip resources that don't have a region AND no custom resourceGroupName
+      // Global resources with a custom RG (e.g. shared ACR) still need RG creation
+      if (!r.region && !hasCustomRG) continue;
 
       const rgName = rgRender.getResourceGroupName(r);
       if (!seen.has(rgName)) {
+        // Determine location for RG: resource.region, config.location, or default
+        const location = r.region ?? (config?.location as string) ?? 'koreacentral';
+
         // Build a minimal synthetic resource with only the fields RG render needs.
-        // Passing the original resource `r` would cause resolveConfig() to generate
-        // capture commands for r's dependencies (e.g. LAW customerId for ACEnv),
-        // which would incorrectly appear in the RG level.
-        // config is intentionally empty — tags are not critical for RG creation
-        // and may contain ParamValues that trigger unwanted capture commands.
         const rgResource: Resource = {
           name: `rg:${rgName}`,
           type: 'AzureResourceGroup',
           ring: r.ring,
-          region: r.region,
+          region: r.region ?? location as Region,
           project: r.project,
           dependencies: [],
-          config: {},
+          config: hasCustomRG ? { resourceGroupName: config.resourceGroupName } : {},
           exports: {},
         };
         const commands = await rgRender.render(rgResource);
@@ -311,7 +312,8 @@ export class Deployer {
    */
   private filterResources(resources: Resource[], options: DeployOptions): Resource[] {
     return resources.filter(resource => {
-      if (options.ring && resource.ring !== options.ring) {
+      // Resources with no ring are global — never filter them out by ring
+      if (options.ring && resource.ring !== undefined && resource.ring !== options.ring) {
         return false;
       }
       // Global resources (e.g. AzureADApp) have no region — never filter them out

--- a/src/kubernetes/kubernetesCluster.ts
+++ b/src/kubernetes/kubernetesCluster.ts
@@ -239,6 +239,9 @@ export class AzureAKSRender extends AzureResourceRender {
 
         this.addTags(args, config.tags);
 
+        // Always generate SSH keys if not present (required for AKS create)
+        args.push('--generate-ssh-keys');
+
         const commands: Command[] = [{ command: 'az', args }];
 
         // CSI Secret Store Provider addon (must be added separately via --enable-addons)


### PR DESCRIPTION
## Summary

- Unify all per-ring/per-region ACRs into a single shared ACR (`brainlysharedacr` in `brainly-rg-shared`), eliminating environment-specific registry proliferation
- Make `ring` optional in resource schema to support global resources (e.g. ACR) that are shared across all environments
- Add `resourceName`/`resourceGroupName` config overrides in `AzureResourceRender` for explicit naming
- Update registry lookup, deployer, compiler, generator, validator, transformer, and paramResolver to handle ring-less resources
- Fix ACR `--location` to be create-only (not sent on update)
- Add `--generate-ssh-keys` to AKS create command
- Update all image references and GitHub SP role assignments to unified ACR

Closes #43

## Test plan

- [x] All 861 non-timeout tests pass (`pnpm test`)
- [x] 26 timeout tests are pre-existing on main (not introduced by this PR)
- [x] `pnpm build` succeeds
- [x] Successfully deployed alluneed to test/koreacentral with unified ACR
- [x] Image imported from old ACR to `brainlysharedacr` and pod running

🤖 Generated with [Claude Code](https://claude.com/claude-code)