### PR TITLE
fix: resolve 26 compiler/integration test timeouts

### DIFF
--- a/src/common/test/compiler.test.ts
+++ b/src/common/test/compiler.test.ts
@@ -2,11 +2,20 @@
  * Compiler orchestrator tests
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Compiler } from '../compiler.js';
 import { createTempDir, cleanupTempDir, writeToTemp, loadFixture } from '../../test-utils/helpers.js';
 import { mkdir } from 'fs/promises';
 import { join } from 'path';
+
+// Mock pnpm availability to skip slow pnpm install/build during tests
+vi.mock('../../compiler/initializer.js', async (importOriginal) => {
+    const original = await importOriginal<typeof import('../../compiler/initializer.js')>();
+    return {
+        ...original,
+        checkPnpmAvailable: vi.fn().mockResolvedValue(false),
+    };
+});
 
 describe('Compiler', () => {
     let tempDir: string;

--- a/src/compiler/test/integration.test.ts
+++ b/src/compiler/test/integration.test.ts
@@ -2,11 +2,20 @@
  * Integration tests for end-to-end compilation
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Compiler } from '../../common/compiler.js';
 import { createTempDir, cleanupTempDir, writeToTemp, loadFixture } from '../../test-utils/helpers.js';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+
+// Mock pnpm availability to skip slow pnpm install/build during tests
+vi.mock('../../compiler/initializer.js', async (importOriginal) => {
+    const original = await importOriginal<typeof import('../../compiler/initializer.js')>();
+    return {
+        ...original,
+        checkPnpmAvailable: vi.fn().mockResolvedValue(false),
+    };
+});
 
 describe('Integration Tests', () => {
     let tempDir: string;


### PR DESCRIPTION
## Summary

- Mock `checkPnpmAvailable()` in `compiler.test.ts` and `integration.test.ts` to skip slow pnpm subprocess calls during tests
- All 887 tests now pass (previously 26 timed out at 5s)
- Total test suite time reduced from ~70s to ~31s

Closes #45

## Test plan

- [x] `pnpm test` — 887/887 passed, 0 failed
- [x] Previously failing tests now complete in <300ms each

🤖 Generated with [Claude Code](https://claude.com/claude-code)