### PR TITLE
fix: --no-shared compiles shared resources but skips deploying them

### DIFF
--- a/docs/project-onboarding.md
+++ b/docs/project-onboarding.md
@@ -1034,6 +1034,7 @@ Merlin 创建的 `AzureServicePrincipal`（在 `shared-resource/sharedgithubsp.y
 
 | 类型 | 名称 | 用途 |
 |------|------|------|
+| Secret | `AKS_AZURE_CLIENT_ID` | SP appId（OIDC 登录 Azure CLI） |
 | Secret | `AKS_ACR_USERNAME` | SP appId（docker login 用户名） |
 | Secret | `AKS_ACR_PASSWORD` | SP client secret（docker login 密码） |
 | Variable | `AKS_ACR_NAME` | ACR 名称（如 `brainlysharedacr`） |

--- a/scripts/setup-github-acr-secrets.sh
+++ b/scripts/setup-github-acr-secrets.sh
@@ -181,6 +181,9 @@ for repo in "${REPO_LIST[@]}"; do
   info "Configuring GitHub repo: $repo"
 
   # Set secrets
+  echo "$SP_APP_ID"  | gh secret set AKS_AZURE_CLIENT_ID --repo "$repo" 2>/dev/null && \
+    ok "  Secret AKS_AZURE_CLIENT_ID set" || warn "  Failed to set AKS_AZURE_CLIENT_ID"
+
   echo "$SP_APP_ID"  | gh secret set AKS_ACR_USERNAME --repo "$repo" 2>/dev/null && \
     ok "  Secret AKS_ACR_USERNAME set" || warn "  Failed to set AKS_ACR_USERNAME"
 
@@ -205,9 +208,10 @@ echo "  Expires:      ~$EXPIRE_DATE"
 echo "  Repos:        ${REPO_LIST[*]}"
 echo ""
 echo "GitHub Actions workflows can now use:"
-echo "  secrets.AKS_ACR_USERNAME  → docker login username"
-echo "  secrets.AKS_ACR_PASSWORD  → docker login password"
-echo "  vars.AKS_ACR_NAME        → ACR registry name"
+echo "  secrets.AKS_AZURE_CLIENT_ID → Azure OIDC login client ID"
+echo "  secrets.AKS_ACR_USERNAME    → docker login username"
+echo "  secrets.AKS_ACR_PASSWORD    → docker login password"
+echo "  vars.AKS_ACR_NAME          → ACR registry name"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 warn "Remember: when the secret expires, re-run this script to rotate it."

--- a/src/common/compiler.ts
+++ b/src/common/compiler.ts
@@ -51,11 +51,15 @@ export class Compiler {
         const generatedFiles: string[] = [];
 
         try {
-            // 1. Discover YAML files (auto-include shared resources from merlin package)
-            const sharedPaths = options.noShared ? [] : await this.getSharedResourcePaths();
+            // 1. Discover YAML files (always include shared resources for ${ } resolution)
+            const sharedPaths = await this.getSharedResourcePaths();
             const allInputPaths = [options.inputPath, ...(options.inputPaths ?? []), ...sharedPaths];
             const yamlFileArrays = await Promise.all(allInputPaths.map(p => this.discoverYAMLFiles(p)));
             const yamlFiles = [...new Set(yamlFileArrays.flat())];
+
+            // Track which files came from shared directories (for --no-shared deploy filtering)
+            const sharedFileArrays = await Promise.all(sharedPaths.map(p => this.discoverYAMLFiles(p)));
+            const sharedFiles = new Set(sharedFileArrays.flat());
             if (yamlFiles.length === 0) {
                 return this.createNoFilesError(options.inputPath);
             }
@@ -124,7 +128,16 @@ export class Compiler {
             // 5. Transform resources (expand ring/region)
             const expandedResources = this.transformResources(expandedYAMLs);
 
-            // 5.5. Merge resources from the same source file (e.g. KubernetesApp expands
+            // 5.5. Mark shared resources (from shared-resource/ and shared-k8s-resource/)
+            for (const entry of expandedResources) {
+                if (sharedFiles.has(entry.source)) {
+                    for (const r of entry.resources) {
+                        r._isShared = true;
+                    }
+                }
+            }
+
+            // 5.6. Merge resources from the same source file (e.g. KubernetesApp expands
             // into multiple resource types, all originating from the same YAML file)
             const mergedResources = this.mergeBySource(expandedResources);
 
@@ -173,8 +186,8 @@ export class Compiler {
      * Reuses compile pipeline steps 1-5, then filters by ring/region.
      */
     async list(options: ListOptions): Promise<ExpandedResource[]> {
-        // 1. Discover YAML files
-        const sharedPaths = options.noShared ? [] : await this.getSharedResourcePaths();
+        // 1. Discover YAML files (always include shared for ${ } resolution)
+        const sharedPaths = await this.getSharedResourcePaths();
         const allInputPaths = [options.inputPath, ...(options.inputPaths ?? []), ...sharedPaths];
         const yamlFileArrays = await Promise.all(allInputPaths.map(p => this.discoverYAMLFiles(p)));
         const yamlFiles = [...new Set(yamlFileArrays.flat())];

--- a/src/common/resource.ts
+++ b/src/common/resource.ts
@@ -72,6 +72,12 @@ export interface Resource<Schema extends ResourceSchema = ResourceSchema> {
     project?: string;
 
     /**
+     * Whether this resource was auto-included from shared-resource/ or shared-k8s-resource/.
+     * Used by the deployer to skip shared resources when --no-shared is active.
+     */
+    _isShared?: boolean;
+
+    /**
      * The parent resource, in "Type.name" format
      * e.g., "AzureContainerAppEnvironment.chuangacenv"
      */

--- a/src/compiler/deploy-script-generator.ts
+++ b/src/compiler/deploy-script-generator.ts
@@ -24,6 +24,7 @@ interface CliOptions {
   execute: boolean;
   outputFile?: string;
   concurrency?: number;
+  noShared?: boolean;
 }
 
 /**
@@ -51,6 +52,8 @@ function parseArguments(): CliOptions {
       if (!isNaN(val) && val > 0) {
         options.concurrency = val;
       }
+    } else if (arg === '--no-shared') {
+      options.noShared = true;
     } else if (arg === '--help' || arg === '-h') {
       console.log(\`
 Usage: node deploy.js [options]
@@ -61,6 +64,7 @@ Options:
   --region <region>          Target region (eastus, westus, eastasia, koreacentral, koreasouth)
   --output, -o <file>        Write generated commands to file
   --concurrency, -c <n>      Max parallel resource deployments per level (default: 4)
+  --no-shared                Skip deploying shared resources (still registered for resolution)
   --help, -h                 Show this help message
 
 Examples:

--- a/src/compiler/generator.ts
+++ b/src/compiler/generator.ts
@@ -113,6 +113,10 @@ function generateResourceObject(resource: ExpandedResource): string {
         code += `  project: ${JSON.stringify(resource.project)},\n`;
     }
 
+    if (resource._isShared) {
+        code += `  _isShared: true,\n`;
+    }
+
     if (resource.parent) {
         code += `  parent: ${JSON.stringify(resource.parent)},\n`;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -86,6 +86,7 @@ export interface ExpandedResource {
     dependencies: DependencyYAML[];  // Use YAML format, not runtime Dependency
     config: Record<string, unknown>;  // Merged defaultConfig + specificConfig
     exports: Record<string, ExportRef>;
+    _isShared?: boolean;     // true if sourced from shared-resource/ or shared-k8s-resource/
 }
 
 /**

--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -30,6 +30,12 @@ export interface DeployOptions {
    * Defaults to 4.
    */
   concurrency?: number;
+  /**
+   * When true, skip deploying shared resources (those with _isShared flag).
+   * Shared resources are still compiled and registered for ${ } expression resolution,
+   * but are filtered out before deployment.
+   */
+  noShared?: boolean;
 }
 
 /** A single resource with its rendered deployment commands */
@@ -283,6 +289,10 @@ export class Deployer {
    */
   private filterResources(resources: Resource[], options: DeployOptions): Resource[] {
     return resources.filter(resource => {
+      // Skip shared resources when --no-shared is active
+      if (options.noShared && resource._isShared) {
+        return false;
+      }
       // Resources with no ring are global — never filter them out by ring
       if (options.ring && resource.ring !== undefined && resource.ring !== options.ring) {
         return false;

--- a/src/merlin.ts
+++ b/src/merlin.ts
@@ -260,6 +260,10 @@ Examples:
                 args.push('--concurrency', options.concurrency);
             }
 
+            if (!options.shared) {
+                args.push('--no-shared');
+            }
+
             if (options.execute) {
                 // Use pnpm execute (which runs with --execute flag)
                 console.log('🚀 Executing deployment...\n');


### PR DESCRIPTION
## Summary
- Always compile shared resources for `${ }` expression resolution, even with `--no-shared`
- Mark shared resources with `_isShared` flag during compilation
- Filter `_isShared` resources in deployer when `--no-shared` is active
- Also adds `AKS_AZURE_CLIENT_ID` to setup script and onboarding docs

Closes #50

## Test plan
- [x] All 889 tests pass
- [x] Build succeeds
- [ ] Verify `merlin deploy --no-shared` no longer errors on `${ }` shared references
- [ ] Verify shared resources are not actually deployed when `--no-shared` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)