### PR TITLE
fix: use getDisplayName() for SP principal ID lookup

### DIFF
--- a/src/azure/authProvider.ts
+++ b/src/azure/authProvider.ts
@@ -1,6 +1,7 @@
 import { AuthProvider, Command, Dependency, Resource, getRender } from "../common/resource.js";
 import { AzureResourceRender } from "./render.js";
 import { AzureADAppRender, AzureADAppResource } from "./azureADApp.js";
+import { AzureServicePrincipalRender, AzureServicePrincipalResource } from "./azureServicePrincipal.js";
 import { toEnvSlug } from '../common/constants.js';
 
 /**
@@ -118,8 +119,12 @@ export class AzureManagedIdentityAuthProvider implements AuthProvider {
 
         // Service Principals are AAD objects, not ARM resources.
         // Their principal ID is the SP's object ID, looked up by display name.
+        // IMPORTANT: must use getDisplayName() (full ring name, e.g. "test") not
+        // getResourceName() (short ring name, e.g. "tst"), because the SP was
+        // created with getDisplayName() in azureServicePrincipal.ts.
         if (requestor.type === 'AzureServicePrincipal') {
-            const displayName = resourceName;
+            const spRender = render as AzureServicePrincipalRender;
+            const displayName = spRender.getDisplayName(requestor as AzureServicePrincipalResource);
             return [{
                 command: 'az',
                 args: ['ad', 'sp', 'list', '--filter', `displayName eq '${displayName}'`, '--query', '[0].id', '-o', 'tsv'],


### PR DESCRIPTION
## Summary

- `buildPrincipalIdCapture()` in `authProvider.ts` was using `getResourceName()` (short ring name like `tst`) to look up Service Principal by display name
- But the SP was created via `getDisplayName()` (full ring name like `test` when `config.displayName` is set)
- This mismatch caused `az ad sp list` filter to return empty → captured variable empty → deploy failure

Closes #68

## Fix

Cast render to `AzureServicePrincipalRender` in the `AzureServicePrincipal` branch and call `getDisplayName()` instead of using `getResourceName()`.

## Test plan

- [ ] All 912 existing tests pass
- [ ] Deploy trinity admin-aad resource with `displayName` containing full ring name
- [ ] Verify `az ad sp list` filter matches the actual SP display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)