### PR TITLE
fix: resolve SP displayName ParamValue, cookie secret length, and CI SP permissions

### DIFF
--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -60,6 +60,15 @@ specificConfig:
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-krc
       - role: Reader
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-eas
+      # Reader on project RGs — needed for ${ } capture commands that resolve
+      # resources in project RGs (e.g. az keyvault show on brainly-rg-tst-krc)
+      - role: Reader
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc
+      - role: Reader
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
+      # DNS Zone Contributor — needed for Ingress bindDnsZone A record creation
+      - role: DNS Zone Contributor
+        scope: /subscriptions/{subscriptionId}/resourceGroups/Trinity-Dev-RG/providers/Microsoft.Network/dnsZones/thebrainly.dev
 
   - ring: staging
     displayName: brainly-github-stg
@@ -100,6 +109,15 @@ specificConfig:
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-krc
       - role: Reader
         scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-eas
+      # Reader on project RGs — needed for ${ } capture commands that resolve
+      # resources in project RGs (e.g. az keyvault show on brainly-rg-stg-krc)
+      - role: Reader
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc
+      - role: Reader
+        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
+      # DNS Zone Contributor — needed for Ingress bindDnsZone A record creation
+      - role: DNS Zone Contributor
+        scope: /subscriptions/{subscriptionId}/resourceGroups/Trinity-Dev-RG/providers/Microsoft.Network/dnsZones/thebrainly.dev
 
 exports:
   clientId: AzureServicePrincipalClientId

--- a/src/azure/authProvider.ts
+++ b/src/azure/authProvider.ts
@@ -2,6 +2,7 @@ import { AuthProvider, Command, Dependency, Resource, getRender } from "../commo
 import { AzureResourceRender } from "./render.js";
 import { AzureADAppRender, AzureADAppResource } from "./azureADApp.js";
 import { AzureServicePrincipalRender, AzureServicePrincipalResource } from "./azureServicePrincipal.js";
+import { resolveConfig } from '../common/paramResolver.js';
 import { toEnvSlug } from '../common/constants.js';
 
 /**
@@ -69,7 +70,7 @@ export class AzureManagedIdentityAuthProvider implements AuthProvider {
 
         // ── Step 1: capture the requestor's managed identity principal ID ──────
         commands.push(
-            ...this.buildPrincipalIdCapture(requestor, requestorRender, principalVar)
+            ...await this.buildPrincipalIdCapture(requestor, requestorRender, principalVar)
         );
 
         // ── Step 2: capture the provider resource's ARM scope ─────────────────
@@ -109,11 +110,11 @@ export class AzureManagedIdentityAuthProvider implements AuthProvider {
      * If the resource type has a dedicated `show` command registered via a
      * known mapping we use that; otherwise we fall back to `az resource show`.
      */
-    private buildPrincipalIdCapture(
+    private async buildPrincipalIdCapture(
         requestor: Resource,
         render: AzureResourceRender,
         varName: string,
-    ): Command[] {
+    ): Promise<Command[]> {
         const resourceName  = render.getResourceName(requestor);
         const resourceGroup = render.getResourceGroupName(requestor);
 
@@ -122,10 +123,14 @@ export class AzureManagedIdentityAuthProvider implements AuthProvider {
         // IMPORTANT: must use getDisplayName() (full ring name, e.g. "test") not
         // getResourceName() (short ring name, e.g. "tst"), because the SP was
         // created with getDisplayName() in azureServicePrincipal.ts.
+        // NOTE: config.displayName may contain ${ } expressions (ParamValue objects)
+        // that are not yet resolved. We must resolveConfig() first so that
+        // getDisplayName() returns the actual string, not "[object Object]".
         if (requestor.type === 'AzureServicePrincipal') {
             const spRender = render as AzureServicePrincipalRender;
-            const displayName = spRender.getDisplayName(requestor as AzureServicePrincipalResource);
-            return [{
+            const { resource: resolved, captureCommands } = await resolveConfig(requestor);
+            const displayName = spRender.getDisplayName(resolved as AzureServicePrincipalResource);
+            return [...captureCommands, {
                 command: 'az',
                 args: ['ad', 'sp', 'list', '--filter', `displayName eq '${displayName}'`, '--query', '[0].id', '-o', 'tsv'],
                 envCapture: varName,

--- a/src/azure/azureServicePrincipal.ts
+++ b/src/azure/azureServicePrincipal.ts
@@ -501,7 +501,7 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
                 command: 'bash',
                 args: ['-c', [
                     `EXISTING=$(az keyvault secret show --vault-name ${kvConfig.vaultNames[0]} --name ${kvConfig.secretName} --query value -o tsv 2>/dev/null || true)`,
-                    `if [ -n "$EXISTING" ]; then echo "$EXISTING"; else openssl rand -base64 32 | tr -d '\\n'; fi`,
+                    `if [ -n "$EXISTING" ]; then echo "$EXISTING"; else openssl rand -hex 16; fi`,
                 ].join('\n')],
                 envCapture: cookieVar,
             },


### PR DESCRIPTION
## Summary
- **authProvider.ts**: call `resolveConfig()` before `getDisplayName()` so `${ }` expressions in `config.displayName` (e.g. `alluneed-aad-${ this.ring }`) are resolved to actual strings instead of `[object Object]`
- **azureServicePrincipal.ts**: change cookie secret generation from `openssl rand -base64 32` (44 chars) to `openssl rand -hex 16` (32 chars) — oauth2-proxy requires exactly 16/24/32 bytes for AES encryption
- **sharedgithubsp.yml**: add Reader on project RGs and DNS Zone Contributor for both test and staging rings

## Test plan
- [x] All 912 tests pass
- [x] Dry-run `merlin deploy` on alluneed (test/koreacentral) confirms `az ad sp list --filter displayName eq 'alluneed-aad-test'` — correct resolved name instead of `[object Object]`
- [ ] Deploy alluneed to verify `MERLIN_MI_ALLUNEED_ALLUNEED_AAD_TST_PRINCIPAL_ID` resolves correctly
- [ ] Deploy sharedgithubsp to apply new role assignments
- [ ] New environment first deploy generates valid 32-char cookie secret

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)