### PR TITLE
feat: add babbage federated credentials to shared resources

### DIFF
--- a/shared-k8s-resource/sharedkvsp.yml
+++ b/shared-k8s-resource/sharedkvsp.yml
@@ -37,6 +37,10 @@ specificConfig:
       - name: alluneed-sa
         issuer: ${ KubernetesCluster.aks.oidcIssuerUrl }
         subject: system:serviceaccount:alluneed:alluneed-workload-sa
+      # Babbage namespace ServiceAccount
+      - name: babbage-sa
+        issuer: ${ KubernetesCluster.aks.oidcIssuerUrl }
+        subject: system:serviceaccount:babbage:babbage-workload-sa
     roleAssignments:
       # Key Vault Secrets User on both regional Key Vaults
       - role: Key Vault Secrets User
@@ -61,6 +65,10 @@ specificConfig:
       - name: alluneed-sa
         issuer: ${ KubernetesCluster.aks.oidcIssuerUrl }
         subject: system:serviceaccount:alluneed:alluneed-workload-sa
+      # Babbage namespace ServiceAccount
+      - name: babbage-sa
+        issuer: ${ KubernetesCluster.aks.oidcIssuerUrl }
+        subject: system:serviceaccount:babbage:babbage-workload-sa
     roleAssignments:
       - role: Key Vault Secrets User
         scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc/providers/Microsoft.KeyVault/vaults/brainlysharedstgkrcakv

--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -28,6 +28,8 @@ specificConfig:
         subject: repo:TheDeltaLab/trinity:environment:nightly
       - name: alluneed-github-test
         subject: repo:TheDeltaLab/alluneed:environment:test
+      - name: babbage-github-nightly
+        subject: repo:TheDeltaLab/babbage:environment:nightly
     roleAssignments:
       # Trinity RG — koreacentral (Container Apps Contributor)
       - role: Container Apps Contributor
@@ -77,6 +79,8 @@ specificConfig:
         subject: repo:TheDeltaLab/trinity:environment:staging
       - name: alluneed-github-staging
         subject: repo:TheDeltaLab/alluneed:environment:staging
+      - name: babbage-github-staging
+        subject: repo:TheDeltaLab/babbage:environment:staging
     roleAssignments:
       # Trinity RG — koreacentral
       - role: Container Apps Contributor


### PR DESCRIPTION
## Summary
- Add `babbage-sa` federated credential to `kv-workload` SP (`sharedkvsp.yml`) for test and staging rings — enables babbage pods to access Key Vault via Workload Identity
- Add `babbage-github-nightly` and `babbage-github-staging` federated credentials to GitHub SP (`sharedgithubsp.yml`) — enables babbage repo's GitHub Actions to authenticate via OIDC

> Note: these credentials were already applied manually via `az ad app federated-credential create`. This PR tracks the changes in YAML source of truth.

Closes #75

## Test plan
- [x] Federated credentials already verified working in babbage CI/CD
- [ ] `merlin deploy shared-resource --execute` applies cleanly
- [ ] `merlin deploy shared-k8s-resource --execute` applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)