### PR TITLE
feat: support custom host template in KubernetesApp ingress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,7 +420,7 @@ Some Azure resources are tenant-scoped and have no region (e.g. `AzureADApp`). S
 
 1. **KubernetesDeployment** (always) — with containers, probes, resource limits, CSI secret volumes, workload identity, auto-dependency on `KubernetesCluster.aks`
 2. **KubernetesService** (always) — ClusterIP service depending on the deployment
-3. **KubernetesIngress** (if `ingress` config present) — with TLS, cert-manager, DNS zone binding
+3. **KubernetesIngress** (if `ingress` config present) — with TLS, cert-manager, DNS zone binding. Host is auto-generated as `{subdomain}.{ring}.{dnsZone}` by default, or can be overridden with the `host` field for custom patterns like `{ring}.{subdomain}.{dnsZone}`.
 
 Override hooks (`deploymentOverrides`, `serviceOverrides`, `ingressOverrides`) allow fine-grained customization of each generated resource. The expansion happens after validation but before ring×region transformation.
 

--- a/docs/project-onboarding.md
+++ b/docs/project-onboarding.md
@@ -152,7 +152,8 @@ defaultConfig:
 | 字段 | 默认值 | 说明 |
 |------|--------|------|
 | `namespace` | 与项目名相同 | K8s namespace，通常不需要改 |
-| `ingress.subdomain` | 与项目名相同 | 最终域名 = `{subdomain}.{ring}.{dnsZone}`，如 `myapp.staging.thebrainly.dev` |
+| `ingress.subdomain` | 与项目名相同 | 默认域名 = `{subdomain}.{ring}.{dnsZone}`，如 `myapp.staging.thebrainly.dev` |
+| `ingress.host` | 自动拼接 | 可选：自定义 host 模板，如 `${ this.ring }.myapp.thebrainly.dev`，覆盖自动拼接 |
 | `envVars` | `APP_ENV=${ this.ring }` | 根据需要添加更多环境变量 |
 | `envFrom` | `secretRef: {name}-secrets` | 对应 SecretProviderClass 生成的 K8s Secret |
 | `serviceAccountName` | `{name}-workload-sa` | 对应 workloadsa.yml 中的 ServiceAccount |
@@ -749,13 +750,14 @@ defaultConfig:
   # ── 可选：Ingress ─────────────────────────────────
   # 省略 → 不生成 Ingress（纯内部服务/worker）
   ingress:
-    subdomain: myapp                      # 必填：子域名
-    dnsZone: thebrainly.dev               # 必填：DNS zone
+    subdomain: myapp                      # 子域名（和 dnsZone 配合自动拼接 host）
+    dnsZone: thebrainly.dev               # DNS zone（也用于 bindDnsZone）
     # 最终域名 = subdomain.{ring}.dnsZone → myapp.staging.thebrainly.dev
+    # host: "${ this.ring }.myapp.thebrainly.dev"  # 可选：自定义 host 模板，覆盖自动拼接
     path: /                               # 默认："/"
     clusterIssuer: letsencrypt-prod       # 默认：letsencrypt-prod
     ingressClassName: nginx               # 默认：nginx
-    bindDnsZone: true                     # 默认：true（自动创建 DNS A 记录）
+    bindDnsZone: true                     # 默认：true（自动创建 DNS A 记录，需要 dnsZone）
     annotations:                          # 额外 Ingress 注解
       nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     dependencies:                         # Ingress 的额外依赖
@@ -792,7 +794,8 @@ specificConfig:
 | `ingress.path` | `/` | |
 | `ingress.ingressClassName` | `nginx` | |
 | `ingress.clusterIssuer` | `letsencrypt-prod` | |
-| `ingress.bindDnsZone` | `true` | 自动创建 DNS A 记录 |
+| `ingress.bindDnsZone` | `true` | 自动创建 DNS A 记录（需要 `dnsZone`） |
+| `ingress.host` | `{subdomain}.{ring}.{dnsZone}` | 自定义时覆盖自动拼接 |
 
 ### 探针默认值（省略 `probes` 时自动生成）
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -43,7 +43,8 @@ function appYml(project: string, opts: { ingress: boolean; withAuth: boolean }):
     const ingressBlock = opts.ingress ? `
   ingress:
     subdomain: ${project}
-    dnsZone: example.com  # TODO: Change to your DNS zone${opts.withAuth ? `
+    dnsZone: example.com  # TODO: Change to your DNS zone
+    # host: "\${ this.ring }.${project}.example.com"  # Optional: custom host pattern (overrides subdomain.ring.dnsZone)${opts.withAuth ? `
     annotations:
       nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
       nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"

--- a/src/compiler/kubernetesAppExpander.ts
+++ b/src/compiler/kubernetesAppExpander.ts
@@ -43,8 +43,11 @@ export interface KubernetesAppConfig {
     envFrom?: Array<Record<string, string>>;
     envVars?: string[];
     ingress?: {
-        subdomain: string;
-        dnsZone: string;
+        /** Custom host template — overrides auto-generated `{subdomain}.{ring}.{dnsZone}` pattern.
+         *  Supports `${ this.ring }` expressions, e.g. `${ this.ring }.web.thebrainly.dev`. */
+        host?: string;
+        subdomain?: string;
+        dnsZone?: string;
         path?: string;
         clusterIssuer?: string;
         ingressClassName?: string;
@@ -253,8 +256,18 @@ function buildIngressResource(resource: ResourceYAML, config: KubernetesAppConfi
     const clusterIssuer = ingress.clusterIssuer ?? DEFAULT_CLUSTER_ISSUER;
     const ingressPath = ingress.path ?? DEFAULT_INGRESS_PATH;
 
-    // Use ${ this.ring } interpolation for dynamic host — eliminates specificConfig
-    const host = `${ingress.subdomain}.\${ this.ring }.${ingress.dnsZone}`;
+    // Use custom host if provided, otherwise auto-generate from subdomain.ring.dnsZone
+    let host: string;
+    if (ingress.host) {
+        host = ingress.host;
+    } else if (ingress.subdomain && ingress.dnsZone) {
+        // Use ${ this.ring } interpolation for dynamic host — eliminates specificConfig
+        host = `${ingress.subdomain}.\${ this.ring }.${ingress.dnsZone}`;
+    } else {
+        throw new Error(
+            `KubernetesApp "${resource.name}": ingress requires either "host" or both "subdomain" and "dnsZone"`,
+        );
+    }
 
     const ingressConfig: Record<string, unknown> = {
         namespace: config.namespace,
@@ -275,8 +288,8 @@ function buildIngressResource(resource: ResourceYAML, config: KubernetesAppConfi
         }],
     };
 
-    // bindDnsZone defaults to true
-    if (ingress.bindDnsZone !== false) {
+    // bindDnsZone defaults to true when dnsZone is available
+    if (ingress.bindDnsZone !== false && ingress.dnsZone) {
         ingressConfig.bindDnsZone = { dnsZone: ingress.dnsZone };
     }
 

--- a/src/compiler/test/kubernetesAppExpander.test.ts
+++ b/src/compiler/test/kubernetesAppExpander.test.ts
@@ -699,6 +699,75 @@ describe('kubernetesAppExpander', () => {
             expect(ingress.specificConfig).toEqual([]);
             expect(ingress.exports).toEqual({});
         });
+
+        it('uses custom host when provided', () => {
+            const resource = createKubernetesApp({
+                ...MINIMAL_CONFIG,
+                ingress: {
+                    host: '${ this.ring }.web.thebrainly.dev',
+                    dnsZone: 'thebrainly.dev',
+                },
+            });
+            const result = expandKubernetesApp(resource);
+            const ingress = result[2];
+            const config = ingress.defaultConfig as Record<string, unknown>;
+            const rules = config.rules as Record<string, unknown>[];
+            const tls = config.tls as Record<string, unknown>[];
+
+            expect(rules[0].host).toBe('${ this.ring }.web.thebrainly.dev');
+            expect(tls[0].hosts).toEqual(['${ this.ring }.web.thebrainly.dev']);
+        });
+
+        it('uses custom host with bindDnsZone when dnsZone is also provided', () => {
+            const resource = createKubernetesApp({
+                ...MINIMAL_CONFIG,
+                ingress: {
+                    host: '${ this.ring }.web.thebrainly.dev',
+                    dnsZone: 'thebrainly.dev',
+                },
+            });
+            const result = expandKubernetesApp(resource);
+            const ingress = result[2];
+            const config = ingress.defaultConfig as Record<string, unknown>;
+
+            expect(config.bindDnsZone).toEqual({ dnsZone: 'thebrainly.dev' });
+        });
+
+        it('skips bindDnsZone when custom host is provided without dnsZone', () => {
+            const resource = createKubernetesApp({
+                ...MINIMAL_CONFIG,
+                ingress: {
+                    host: '${ this.ring }.web.thebrainly.dev',
+                },
+            });
+            const result = expandKubernetesApp(resource);
+            const ingress = result[2];
+            const config = ingress.defaultConfig as Record<string, unknown>;
+
+            expect(config.bindDnsZone).toBeUndefined();
+        });
+
+        it('throws when neither host nor subdomain+dnsZone is provided', () => {
+            const resource = createKubernetesApp({
+                ...MINIMAL_CONFIG,
+                ingress: {} as never,
+            });
+
+            expect(() => expandKubernetesApp(resource)).toThrow(
+                'ingress requires either "host" or both "subdomain" and "dnsZone"',
+            );
+        });
+
+        it('throws when only subdomain is provided without dnsZone', () => {
+            const resource = createKubernetesApp({
+                ...MINIMAL_CONFIG,
+                ingress: { subdomain: 'web' } as never,
+            });
+
+            expect(() => expandKubernetesApp(resource)).toThrow(
+                'ingress requires either "host" or both "subdomain" and "dnsZone"',
+            );
+        });
     });
 
     describe('full integration: complex app', () => {


### PR DESCRIPTION
## Summary
- Add optional `host` field to `KubernetesApp` ingress config, allowing custom host patterns like `${ this.ring }.web.thebrainly.dev` instead of the fixed `{subdomain}.{ring}.{dnsZone}` format
- `subdomain` becomes optional when `host` is provided; `dnsZone` still needed for `bindDnsZone`
- Clear error message when neither `host` nor `subdomain`+`dnsZone` is given
- 5 new tests, updated docs and init templates

## Usage

```yaml
# Default (unchanged)
ingress:
  subdomain: web
  dnsZone: thebrainly.dev
  # → web.staging.thebrainly.dev

# Custom host pattern
ingress:
  host: "${ this.ring }.web.thebrainly.dev"
  dnsZone: thebrainly.dev
  # → staging.web.thebrainly.dev
```

Closes #78

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 917 tests pass (5 new)
- [ ] `merlin init testapp` generates template with `host` comment hint
- [ ] Existing projects using `subdomain`+`dnsZone` continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)