### PR TITLE
feat: upgrade GitHub SP to full CI/CD deploy permissions

### DIFF
--- a/scripts/setup-github-sp-permissions.sh
+++ b/scripts/setup-github-sp-permissions.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Setup GitHub Actions SP permissions for full CI/CD deploy
+#
+# Prerequisites:
+#   - az login with an account that has:
+#     • Owner on the subscription
+#     • Global Administrator (or Privileged Role Administrator) in Azure AD
+#   - The SP must already exist (created by a previous `merlin deploy shared-resource`)
+#
+# Usage:
+#   ./scripts/setup-github-sp-permissions.sh          # both rings
+#   ./scripts/setup-github-sp-permissions.sh test      # test only
+#   ./scripts/setup-github-sp-permissions.sh staging   # staging only
+#
+# All commands are idempotent — safe to re-run.
+# ============================================================================
+
+RING="${1:-all}"
+
+setup_sp() {
+    local display_name="$1"
+    local ring_label="$2"
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════"
+    echo "  Setting up: $display_name ($ring_label)"
+    echo "═══════════════════════════════════════════════════════════"
+
+    # ── 1. Resolve SP app ID ──────────────────────────────────────
+    echo "→ Looking up app ID for '$display_name'..."
+    APP_ID=$(az ad app list --filter "displayName eq '$display_name'" --query '[0].appId' -o tsv)
+    if [ -z "$APP_ID" ]; then
+        echo "✘ ERROR: SP '$display_name' not found. Run 'merlin deploy shared-resource' first."
+        return 1
+    fi
+    echo "  App ID: $APP_ID"
+
+    # ── 2. MS Graph API permissions ───────────────────────────────
+    echo "→ Setting MS Graph API permissions (Application.ReadWrite.All, AppRoleAssignment.ReadWrite.All, Directory.Read.All)..."
+    az ad app update --id "$APP_ID" --required-resource-accesses '[{
+        "resourceAppId": "00000003-0000-0000-c000-000000000000",
+        "resourceAccess": [
+            {"id": "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9", "type": "Role"},
+            {"id": "06b708a9-e830-4db3-a914-8e69da51d44f", "type": "Role"},
+            {"id": "7ab1d382-f21e-4acd-a863-ba3e13f7da61", "type": "Role"}
+        ]
+    }]'
+
+    # ── 3. Admin consent ──────────────────────────────────────────
+    echo "→ Granting admin consent..."
+    az ad app permission admin-consent --id "$APP_ID" || echo "  ⚠ Admin consent failed — may need Global Admin to approve in Azure Portal"
+
+    # ── 4. ARM RBAC role assignments (subscription-level) ─────────
+    SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+    echo "→ Assigning ARM roles on subscription $SUBSCRIPTION_ID..."
+
+    declare -a ROLES=(
+        "Contributor"
+        "User Access Administrator"
+        "AcrPush"
+        "Azure Kubernetes Service Cluster User Role"
+        "Azure Kubernetes Service RBAC Writer"
+        "Key Vault Secrets Officer"
+    )
+
+    for role in "${ROLES[@]}"; do
+        echo "  • $role"
+        az role assignment create \
+            --assignee "$APP_ID" \
+            --role "$role" \
+            --scope "/subscriptions/$SUBSCRIPTION_ID" 2>/dev/null || true
+    done
+
+    # ── 5. Directory roles (tenant-level) ─────────────────────────
+    SP_OID=$(az ad sp list --filter "appId eq '$APP_ID'" --query '[0].id' -o tsv)
+    echo "→ Assigning directory roles (SP object ID: $SP_OID)..."
+
+    # Directory Readers
+    echo "  • Directory Readers"
+    az rest --method post --url "https://graph.microsoft.com/v1.0/directoryRoles" \
+        --headers "Content-Type=application/json" \
+        --body '{"roleTemplateId":"88d8e3e3-8f55-4a1e-953a-9b9898b8876b"}' 2>/dev/null || true
+    DIR_READER_ID=$(az rest --method get --url "https://graph.microsoft.com/v1.0/directoryRoles" \
+        -o tsv --query "value[?roleTemplateId=='88d8e3e3-8f55-4a1e-953a-9b9898b8876b'].id | [0]")
+    az rest --method post \
+        --url "https://graph.microsoft.com/v1.0/directoryRoles/$DIR_READER_ID/members/\$ref" \
+        --headers "Content-Type=application/json" \
+        --body "{\"@odata.id\":\"https://graph.microsoft.com/v1.0/servicePrincipals/$SP_OID\"}" 2>/dev/null || true
+
+    # Application Administrator
+    echo "  • Application Administrator"
+    az rest --method post --url "https://graph.microsoft.com/v1.0/directoryRoles" \
+        --headers "Content-Type=application/json" \
+        --body '{"roleTemplateId":"9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3"}' 2>/dev/null || true
+    APP_ADMIN_ID=$(az rest --method get --url "https://graph.microsoft.com/v1.0/directoryRoles" \
+        -o tsv --query "value[?roleTemplateId=='9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3'].id | [0]")
+    az rest --method post \
+        --url "https://graph.microsoft.com/v1.0/directoryRoles/$APP_ADMIN_ID/members/\$ref" \
+        --headers "Content-Type=application/json" \
+        --body "{\"@odata.id\":\"https://graph.microsoft.com/v1.0/servicePrincipals/$SP_OID\"}" 2>/dev/null || true
+
+    echo "✔ Done: $display_name"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo "Checking Azure login..."
+az account show --query '{subscription: name, user: user.name}' -o table || {
+    echo "✘ Not logged in. Run 'az login' first."
+    exit 1
+}
+echo ""
+
+if [ "$RING" = "all" ] || [ "$RING" = "test" ]; then
+    setup_sp "brainly-github-tst" "test"
+fi
+
+if [ "$RING" = "all" ] || [ "$RING" = "staging" ]; then
+    setup_sp "brainly-github-stg" "staging"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════════"
+echo "  ✅ All done!"
+echo ""
+echo "  To verify, run:"
+echo "    az role assignment list --assignee <APP_ID> --all --output table"
+echo "    az rest --method get --url 'https://graph.microsoft.com/v1.0/servicePrincipals/<SP_OID>/memberOf' --query 'value[].displayName'"
+echo "═══════════════════════════════════════════════════════════"

--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -14,11 +14,50 @@ defaultConfig:
   tags:
     merlin: "true"
     env: ${ this.ring }
-  # Directory Readers — allows the SP to query AD apps/SPs via MS Graph
-  # (needed for K8s ${ } capture commands like `az ad app list`)
-  # ⚠️ Requires Global Admin to deploy
+
+  # ── MS Graph API permissions (Application type) ──────────────────────
+  # These grant the SP programmatic access to Azure AD / Entra ID.
+  # ⚠️ Requires admin consent (auto-attempted, but may need Global Admin)
+  apiPermissions:
+    - resourceAppId: "00000003-0000-0000-c000-000000000000"  # Microsoft Graph
+      resourceAccess:
+        # Application.ReadWrite.All — create/update AD Apps, SPs, federated credentials, client secrets
+        - id: "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9"
+          type: Role
+        # AppRoleAssignment.ReadWrite.All — manage app role assignments (EntraID auth provider)
+        - id: "06b708a9-e830-4db3-a914-8e69da51d44f"
+          type: Role
+        # Directory.Read.All — read directory data (query directory roles)
+        - id: "7ab1d382-f21e-4acd-a863-ba3e13f7da61"
+          type: Role
+
+  # ── Azure AD directory roles (tenant-level) ─────────────────────────
+  # ⚠️ Requires Global Admin or Privileged Role Administrator to deploy
   directoryRoles:
     - Directory Readers
+    - Application Administrator
+
+  # ── ARM RBAC role assignments (subscription-level) ──────────────────
+  # All at subscription scope so new regions/RGs/resources work automatically.
+  roleAssignments:
+    # Contributor — create/update all ARM resources (RG, ACA, ACR, Storage, KV, Redis, PG, LAW, DNS, FunctionApp, AKS)
+    - role: Contributor
+      scope: /subscriptions/{subscriptionId}
+    # User Access Administrator — create role assignments (authProvider, SP roleAssignments)
+    - role: User Access Administrator
+      scope: /subscriptions/{subscriptionId}
+    # AcrPush — push Docker images (Contributor doesn't include ACR data-plane push)
+    - role: AcrPush
+      scope: /subscriptions/{subscriptionId}
+    # AKS Cluster User — az aks get-credentials
+    - role: Azure Kubernetes Service Cluster User Role
+      scope: /subscriptions/{subscriptionId}
+    # AKS RBAC Writer — kubectl apply (K8s data-plane write)
+    - role: Azure Kubernetes Service RBAC Writer
+      scope: /subscriptions/{subscriptionId}
+    # Key Vault Secrets Officer — read/write KV secrets (Contributor doesn't include KV data-plane)
+    - role: Key Vault Secrets Officer
+      scope: /subscriptions/{subscriptionId}
 
 specificConfig:
   - ring: test
@@ -30,47 +69,6 @@ specificConfig:
         subject: repo:TheDeltaLab/alluneed:environment:test
       - name: babbage-github-nightly
         subject: repo:TheDeltaLab/babbage:environment:nightly
-    roleAssignments:
-      # Trinity RG — koreacentral (Container Apps Contributor)
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc
-      # Trinity RG — eastasia
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
-      # Alluneed RG — koreacentral
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc
-      # Alluneed RG — eastasia
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
-      # ACR — shared (brainlysharedacr, used by all rings)
-      - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-shared/providers/Microsoft.ContainerRegistry/registries/brainlysharedacr
-      # AKS — kubectl access for K8s deploys (shared RG)
-      - role: Azure Kubernetes Service Cluster User Role
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-krc
-      - role: Azure Kubernetes Service Cluster User Role
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-eas
-      # AKS — K8s RBAC write for kubectl apply (Deployments, Services, Ingress, ConfigMaps, etc.)
-      - role: Azure Kubernetes Service RBAC Writer
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-krc
-      - role: Azure Kubernetes Service RBAC Writer
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-eas
-      # Reader on shared RGs — needed for K8s ${ } capture commands
-      # (az keyvault show, az redisenterprise show, etc.)
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-krc
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-tst-eas
-      # Reader on project RGs — needed for ${ } capture commands that resolve
-      # resources in project RGs (e.g. az keyvault show on brainly-rg-tst-krc)
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-krc
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-tst-eas
-      # DNS Zone Contributor — needed for Ingress bindDnsZone A record creation
-      - role: DNS Zone Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/Trinity-Dev-RG/providers/Microsoft.Network/dnsZones/thebrainly.dev
 
   - ring: staging
     displayName: brainly-github-stg
@@ -81,47 +79,6 @@ specificConfig:
         subject: repo:TheDeltaLab/alluneed:environment:staging
       - name: babbage-github-staging
         subject: repo:TheDeltaLab/babbage:environment:staging
-    roleAssignments:
-      # Trinity RG — koreacentral
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc
-      # Trinity RG — eastasia
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
-      # Alluneed RG — koreacentral
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc
-      # Alluneed RG — eastasia
-      - role: Container Apps Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
-      # ACR — shared (brainlysharedacr, used by all rings)
-      - role: AcrPush
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-shared/providers/Microsoft.ContainerRegistry/registries/brainlysharedacr
-      # AKS — kubectl access for K8s deploys (shared RG)
-      - role: Azure Kubernetes Service Cluster User Role
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-krc
-      - role: Azure Kubernetes Service Cluster User Role
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-eas
-      # AKS — K8s RBAC write for kubectl apply (Deployments, Services, Ingress, ConfigMaps, etc.)
-      - role: Azure Kubernetes Service RBAC Writer
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-krc
-      - role: Azure Kubernetes Service RBAC Writer
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-eas
-      # Reader on shared RGs — needed for K8s ${ } capture commands
-      # (az keyvault show, az redisenterprise show, etc.)
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-krc
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/shared-rg-stg-eas
-      # Reader on project RGs — needed for ${ } capture commands that resolve
-      # resources in project RGs (e.g. az keyvault show on brainly-rg-stg-krc)
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-krc
-      - role: Reader
-        scope: /subscriptions/{subscriptionId}/resourceGroups/brainly-rg-stg-eas
-      # DNS Zone Contributor — needed for Ingress bindDnsZone A record creation
-      - role: DNS Zone Contributor
-        scope: /subscriptions/{subscriptionId}/resourceGroups/Trinity-Dev-RG/providers/Microsoft.Network/dnsZones/thebrainly.dev
 
 exports:
   clientId: AzureServicePrincipalClientId

--- a/src/common/compiler.ts
+++ b/src/common/compiler.ts
@@ -55,11 +55,11 @@ export class Compiler {
             const sharedPaths = await this.getSharedResourcePaths();
             const allInputPaths = [options.inputPath, ...(options.inputPaths ?? []), ...sharedPaths];
             const yamlFileArrays = await Promise.all(allInputPaths.map(p => this.discoverYAMLFiles(p)));
-            const yamlFiles = [...new Set(yamlFileArrays.flat())];
+            const yamlFiles = [...new Set(yamlFileArrays.flat().map(f => path.resolve(f)))];
 
             // Track which files came from shared directories (for --no-shared deploy filtering)
             const sharedFileArrays = await Promise.all(sharedPaths.map(p => this.discoverYAMLFiles(p)));
-            const sharedFiles = new Set(sharedFileArrays.flat());
+            const sharedFiles = new Set(sharedFileArrays.flat().map(f => path.resolve(f)));
             if (yamlFiles.length === 0) {
                 return this.createNoFilesError(options.inputPath);
             }


### PR DESCRIPTION
## Summary

- Upgrade shared GitHub SP from per-RG K8s-only roles to subscription-level full deploy permissions
- Add MS Graph API permissions (`Application.ReadWrite.All`, `AppRoleAssignment.ReadWrite.All`, `Directory.Read.All`)
- Add `Application Administrator` directory role for admin consent
- Move `roleAssignments` to `defaultConfig` — both rings share identical subscription-scoped roles, no more duplication
- Add `scripts/setup-github-sp-permissions.sh` for one-time Global Admin setup
- Fix compiler duplicate resource error from path normalization failure (relative vs absolute)

## Test plan

- [x] `pnpm test` — 917 tests pass
- [x] `merlin deploy shared-resource --ring test` dry-run succeeds
- [x] Script syntax check (`bash -n`) passes
- [x] SP lookup, role assignment list, directory role API verified against live Azure
- [ ] Global Admin runs `./scripts/setup-github-sp-permissions.sh` to apply

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)