### PR TITLE
feat: add synapse GitHub federated credentials to shared SP

### DIFF
--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -69,6 +69,8 @@ specificConfig:
         subject: repo:TheDeltaLab/alluneed:environment:test
       - name: babbage-github-nightly
         subject: repo:TheDeltaLab/babbage:environment:nightly
+      - name: synapse-github-nightly
+        subject: repo:TheDeltaLab/synapse:environment:nightly
 
   - ring: staging
     displayName: brainly-github-stg
@@ -79,6 +81,8 @@ specificConfig:
         subject: repo:TheDeltaLab/alluneed:environment:staging
       - name: babbage-github-staging
         subject: repo:TheDeltaLab/babbage:environment:staging
+      - name: synapse-github-staging
+        subject: repo:TheDeltaLab/synapse:environment:staging
 
 exports:
   clientId: AzureServicePrincipalClientId


### PR DESCRIPTION
## Summary
- Add `synapse-github-nightly` and `synapse-github-staging` federated credentials to `sharedgithubsp.yml`
- Enables synapse's AKS deploy workflow to authenticate via OIDC to Azure

The nightly credential has already been added manually via `az ad app federated-credential create`. This PR syncs the YAML to match.

Closes #91

## Test plan
- [ ] `merlin compile` succeeds
- [ ] Synapse AKS deploy workflow authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)