### PR TITLE
fix: replace az ad sp list with az ad sp show + create fallback

### DIFF
--- a/src/azure/azureServicePrincipal.ts
+++ b/src/azure/azureServicePrincipal.ts
@@ -369,8 +369,8 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
         // Capture the SP's object ID (we need the SP object, not the app object)
         const spObjectIdVar = this.envVarName(resource, 'SP_OID');
         commands.push({
-            command: 'az',
-            args: ['ad', 'sp', 'list', '--filter', `appId eq '$${appIdVar}'`, '--query', '[0].id', '-o', 'tsv'],
+            command: 'bash',
+            args: ['-c', `az ad sp show --id $${appIdVar} --query id -o tsv 2>/dev/null || az ad sp create --id $${appIdVar} --query id -o tsv`],
             envCapture: spObjectIdVar,
         });
 
@@ -449,10 +449,12 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
         const spObjectIdVar = this.envVarName(resource, 'SP_OBJECT_ID');
         const value = resource.config.assignmentRequired ? 'true' : 'false';
         return [
-            // Capture the SP's object ID (different from appId)
+            // Capture the SP's object ID — use `az ad sp show` (direct lookup by appId)
+            // which is more reliable than `az ad sp list --filter` after a recent create.
+            // If the SP doesn't exist yet, create it first.
             {
-                command: 'az',
-                args: ['ad', 'sp', 'list', '--filter', `appId eq '$${appIdVar}'`, '--query', '[0].id', '-o', 'tsv'],
+                command: 'bash',
+                args: ['-c', `az ad sp show --id $${appIdVar} --query id -o tsv 2>/dev/null || az ad sp create --id $${appIdVar} --query id -o tsv`],
                 envCapture: spObjectIdVar,
             },
             // Set appRoleAssignmentRequired on the Service Principal

--- a/src/azure/test/azureServicePrincipal.test.ts
+++ b/src/azure/test/azureServicePrincipal.test.ts
@@ -119,14 +119,13 @@ describe('AzureServicePrincipalRender', () => {
             expect(cmds).toHaveLength(2);
         });
 
-        it('captures SP object ID with az ad sp list', () => {
+        it('captures SP object ID with az ad sp show (fallback to create)', () => {
             const resource = makeResource({ directoryRoles: ['Directory Readers'] });
             const cmds = render.renderDirectoryRoles(resource, APP_ID_VAR);
             const captureCmd = cmds[0];
-            expect(captureCmd.command).toBe('az');
-            expect(captureCmd.args).toContain('ad');
-            expect(captureCmd.args).toContain('sp');
-            expect(captureCmd.args).toContain('list');
+            expect(captureCmd.command).toBe('bash');
+            expect(captureCmd.args[1]).toContain('az ad sp show');
+            expect(captureCmd.args[1]).toContain('az ad sp create');
             expect(captureCmd.envCapture).toBeDefined();
             expect(captureCmd.envCapture).toContain('SP_OID');
         });


### PR DESCRIPTION
## Summary
- Replace all `az ad sp list --filter "appId eq '...'"` with `az ad sp show --id` for SP object ID lookup
- Add fallback to `az ad sp create` if SP doesn't exist
- Fixes both `renderAssignmentRequired` (SP_OBJECT_ID) and `renderDirectoryRoles` (SP_OID)

## Root cause
PR #97 added `az ad sp create || true` in the update path, but `renderAssignmentRequired` still used `az ad sp list --filter` which is unreliable:
1. `az ad sp list --filter` can return empty due to eventual consistency
2. If SP doesn't exist, the filter returns empty instead of an error

The new approach: `az ad sp show --id $APP_ID || az ad sp create --id $APP_ID` — show first (fast, direct lookup), create as fallback, both return the object ID.

Closes #96

## Test plan
- [x] All 917 tests pass
- [ ] Lovelace CI deploys successfully with new merlin version

🤖 Generated with [Claude Code](https://claude.com/claude-code)