### PR TITLE
fix: make AzureServicePrincipal client secret generation idempotent

### DIFF
--- a/src/azure/azureServicePrincipal.ts
+++ b/src/azure/azureServicePrincipal.ts
@@ -281,7 +281,7 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
         // 5. Configure assignment required (access control)
         commands.push(...this.renderAssignmentRequired(resource, appIdVar));
 
-        // 5. Client secret → Key Vault (create-only, not on update to avoid breaking running services)
+        // 5. Client secret → Key Vault (idempotent — only resets credential if KV is missing it)
         commands.push(...this.renderClientSecret(resource, appIdVar));
 
         // 6. Cookie secret → Key Vault (idempotent — only creates if missing)
@@ -336,6 +336,9 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
 
         // Cookie secret → Key Vault (idempotent — only creates if missing)
         commands.push(...this.renderCookieSecret(resource));
+
+        // Client secret → Key Vault (idempotent — only resets credential if KV is missing it)
+        commands.push(...this.renderClientSecret(resource, appIdVar));
 
         commands.push(...this.renderFederatedCredentials(resource, appIdVar));
         commands.push(...this.renderRoleAssignments(resource, appIdVar));
@@ -465,23 +468,37 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
         ];
     }
 
-    // ── Client secret → Key Vault ─────────────────────────────────────────
+    // ── Client secret → Key Vault (idempotent) ───────────────────────────
 
+    /**
+     * Ensure a client secret exists in Key Vault for the AD App.
+     * Idempotent: checks the first vault — if the secret already exists, reuses it.
+     * Only when missing, resets the AD App credential (rotating it) and writes to all vaults.
+     *
+     * Safe to call on both create and update:
+     *   - First deploy: KV empty → reset credential → write to KV.
+     *   - Subsequent deploys: KV has value → reuse (no rotation).
+     *   - KV secret deleted manually / App pre-existed / earlier deploy partially failed:
+     *     KV empty → self-heal by resetting credential and re-populating KV.
+     */
     renderClientSecret(resource: AzureServicePrincipalResource, appIdVar: string): Command[] {
         const kvConfig = resource.config.clientSecretKeyVault;
         if (!kvConfig) return [];
 
         const secretVar = this.envVarName(resource, 'CLIENT_SECRET');
         const commands: Command[] = [
-            // Generate a new client secret and capture its value
+            // Reuse existing KV value if present; otherwise reset AD App credential.
             {
-                command: 'az',
-                args: ['ad', 'app', 'credential', 'reset', '--id', `$${appIdVar}`, '--query', 'password', '-o', 'tsv'],
+                command: 'bash',
+                args: ['-c', [
+                    `EXISTING=$(az keyvault secret show --vault-name ${kvConfig.vaultNames[0]} --name ${kvConfig.secretName} --query value -o tsv 2>/dev/null || true)`,
+                    `if [ -n "$EXISTING" ]; then echo "$EXISTING"; else az ad app credential reset --id $${appIdVar} --query password -o tsv; fi`,
+                ].join('\n')],
                 envCapture: secretVar,
             },
         ];
 
-        // Store it in every Key Vault (for multi-region setups)
+        // Store in every Key Vault (idempotent — overwrites with same value if exists)
         for (const vaultName of kvConfig.vaultNames) {
             commands.push({
                 command: 'az',

--- a/src/azure/test/azureServicePrincipal.test.ts
+++ b/src/azure/test/azureServicePrincipal.test.ts
@@ -203,6 +203,102 @@ describe('AzureServicePrincipalRender', () => {
         });
     });
 
+    // ── 4b. renderClientSecret (idempotent) ──────────────────────────────────
+
+    describe('renderClientSecret', () => {
+        const APP_ID_VAR = 'MERLIN_SP_BRAINLY_GITHUB_TST_APP_ID';
+
+        it('returns empty array when no clientSecretKeyVault configured', () => {
+            const resource = makeResource();
+            const cmds = render.renderClientSecret(resource, APP_ID_VAR);
+            expect(cmds).toHaveLength(0);
+        });
+
+        it('emits an idempotent bash block that reuses KV value if present, else resets credential', () => {
+            const resource = makeResource({
+                clientSecretKeyVault: {
+                    vaultNames: ['brainlysharedtstkrcakv'],
+                    secretName: 'lovelace-oauth2-proxy-client-secret',
+                },
+            });
+            const cmds = render.renderClientSecret(resource, APP_ID_VAR);
+
+            // 1 capture bash + 1 keyvault secret set
+            expect(cmds).toHaveLength(2);
+            const captureCmd = cmds[0];
+            expect(captureCmd.command).toBe('bash');
+            expect(captureCmd.envCapture).toBeDefined();
+            expect(captureCmd.envCapture).toContain('CLIENT_SECRET');
+
+            const script = captureCmd.args[1];
+            // Reads existing secret from first vault
+            expect(script).toContain('az keyvault secret show');
+            expect(script).toContain('brainlysharedtstkrcakv');
+            expect(script).toContain('lovelace-oauth2-proxy-client-secret');
+            // Falls back to credential reset when missing
+            expect(script).toContain('az ad app credential reset');
+            expect(script).toContain(`$${APP_ID_VAR}`);
+            // Branching with EXISTING variable
+            expect(script).toContain('EXISTING');
+            expect(script).toContain('if [ -n "$EXISTING" ]');
+        });
+
+        it('writes the captured secret into every configured vault', () => {
+            const resource = makeResource({
+                clientSecretKeyVault: {
+                    vaultNames: ['vault-a', 'vault-b', 'vault-c'],
+                    secretName: 'my-secret',
+                },
+            });
+            const cmds = render.renderClientSecret(resource, APP_ID_VAR);
+
+            // 1 capture + 3 vault writes
+            expect(cmds).toHaveLength(4);
+            const vaults = cmds.slice(1).map(c => c.args[c.args.indexOf('--vault-name') + 1]);
+            expect(vaults).toEqual(['vault-a', 'vault-b', 'vault-c']);
+            cmds.slice(1).forEach(c => {
+                expect(c.command).toBe('az');
+                expect(c.args).toContain('secret');
+                expect(c.args).toContain('set');
+                expect(c.args).toContain('my-secret');
+            });
+        });
+    });
+
+    // ── 4c. renderUpdate invokes renderClientSecret ──────────────────────────
+
+    describe('renderUpdate with clientSecretKeyVault', () => {
+        it('includes idempotent client secret commands on update flow', () => {
+            const resource = makeResource({
+                displayName: 'brainly-github-tst',
+                clientSecretKeyVault: {
+                    vaultNames: ['brainlysharedtstkrcakv'],
+                    secretName: 'lovelace-oauth2-proxy-client-secret',
+                },
+            });
+            const cmds = render.renderUpdate(resource, 'app-id-123', 'object-id-123');
+
+            // Find the bash capture emitted by renderClientSecret
+            const captureCmd = cmds.find(
+                c => c.command === 'bash'
+                    && c.envCapture
+                    && c.envCapture.includes('CLIENT_SECRET')
+            );
+            expect(captureCmd).toBeDefined();
+            expect(captureCmd!.args[1]).toContain('az keyvault secret show');
+            expect(captureCmd!.args[1]).toContain('az ad app credential reset');
+
+            // And the subsequent keyvault secret set
+            const setCmd = cmds.find(
+                c => c.command === 'az'
+                    && c.args.includes('secret')
+                    && c.args.includes('set')
+                    && c.args.includes('lovelace-oauth2-proxy-client-secret')
+            );
+            expect(setCmd).toBeDefined();
+        });
+    });
+
     // ── 5. renderRoleAssignments ─────────────────────────────────────────────
 
     describe('renderRoleAssignments', () => {


### PR DESCRIPTION
## Summary
- `renderClientSecret` now checks Key Vault first and reuses the existing value instead of always rotating
- Called from both `renderCreate` and `renderUpdate`, so SPs whose KV secret is missing (e.g. pre-existing Apps, or prior partial failures) self-heal on the next deploy
- No schema changes; behavior is strictly a self-healing improvement

Closes #102

## Test plan
- [x] New unit tests: `renderClientSecret` emits the idempotent bash block and writes to each vault
- [x] New test: `renderUpdate` includes the client-secret commands when `clientSecretKeyVault` is configured
- [x] Full test suite (921 tests) passes
- [ ] Deploy updated merlin against `lovelace-aad` → `lovelace-oauth2-proxy-client-secret` appears in `brainlysharedtstkrcakv`
- [ ] oauth2-proxy pods transition from `ContainerCreating` to `Running`
- [ ] Second deploy run does NOT rotate the secret (value unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)