### PR TITLE
docs: add HA/replicas best-practice guide for production

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -674,6 +674,47 @@ merlin deploy ./merlin-resources --ring test --region koreacentral --execute
 
 ---
 
+## 上线生产前 checklist
+
+`merlin init` 生成的配置默认面向 dev/test。**正式投到 production 前**，逐项确认：
+
+### 副本数与可用性
+
+- [ ] **用户面向应用（web/admin/home）配 `replicas: 2+`** — `defaultConfig.replicas` 默认是 1，单副本意味着 pod 重启 / 节点维护期间整个服务 503。建议在 `specificConfig` 按 ring 区分：
+  ```yaml
+  specificConfig:
+    - ring: staging
+      replicas: 2
+    - ring: production
+      replicas: 3
+  ```
+- [ ] **内部 API（lance、gateway 等）至少考虑 `replicas: 2`**，看流量定
+- [ ] **异步 worker 暂时单副本**（HPA 还未支持，按队列堆积情况手动调）
+- [ ] **健康检查路径正确** — `healthPath` 必须返回 200，且应反映"真实可服务能力"（包含下游依赖检查），不要用永远返回 200 的桩
+- [ ] **应用必须无状态** — 不依赖本地内存/磁盘的会话或缓存，否则不能多副本
+
+副本数推荐表和决策依据见 [KubernetesApp YAML 参考 → 副本数推荐](kubernetes-app-reference.md#副本数推荐)。
+
+### 资源与扩展
+
+- [ ] **resources 设置合理** — 按实际负载估算 `cpuRequest/memoryRequest`，prod 不要直接用模板默认值
+- [ ] **依赖资源能扛住 N 倍连接** — Postgres 连接池、Redis、上游 API 配额要按 `replicas × 单 pod 池大小` 评估
+- [ ] **生产 ring 在 `merlin.yml` 列出** — 默认模板只有 test，prod 需手动加 `ring: [test, staging, production]`
+
+### 安全
+
+- [ ] **公网入口必须有认证** — 用户面向应用走 oauth2-proxy（`--with-auth` 模板自动配好）；webhook/回调端点用共享 secret
+- [ ] **Key Vault 联邦凭证已配** — 本项目 ServiceAccount 已加到 `shared-k8s-resource/sharedkvsp.yml`，且 merlin 已重新部署 shared SP（见 [排错指南](troubleshooting.md)）
+- [ ] **GitHub SP 联邦凭证已配** — 本项目 GitHub Actions workflow 已加到 `sharedgithubsp.yml`
+
+### 部署流程
+
+- [ ] **CI/CD 配通** — 见 [CI/CD 指南](cicd-guide.md)，至少 `nightly` build 自动推 ACR
+- [ ] **先 dry-run 再 execute** — `merlin deploy --ring production --region <region>` 确认输出无误后再加 `--execute`
+- [ ] **观察 5 分钟** — `kubectl get pods -n <namespace>` 确认所有副本都 Ready，无 CrashLoopBackOff
+
+---
+
 ## 下一步
 
 - **详细字段说明** → [KubernetesApp YAML 参考](kubernetes-app-reference.md)

--- a/docs/kubernetes-app-reference.md
+++ b/docs/kubernetes-app-reference.md
@@ -139,7 +139,7 @@ specificConfig:
 
 | 字段 | 默认值 | 说明 |
 |------|--------|------|
-| `replicas` | `1` | |
+| `replicas` | `1` | 见下方「副本数推荐」 |
 | `healthPath` | `/` | 用于所有探针 |
 | `imagePullPolicy` | `IfNotPresent` | |
 | `resources.cpuRequest` | `250m` | |
@@ -159,6 +159,57 @@ specificConfig:
 | startup | HTTP GET | `healthPath` | initialDelay=1s, period=1s, failure=240 |
 | liveness | HTTP GET | `healthPath` | period=10s, timeout=5s, failure=3 |
 | readiness | HTTP GET | `healthPath` | period=5s, timeout=5s, failure=48 |
+
+### 副本数推荐
+
+`replicas` 默认 `1`，**生产环境的用户面向应用必须显式设置成 ≥ 2** 以避免单点故障。
+
+| Workload 类型 | test | staging | production | 备注 |
+|--------------|------|---------|-----------|------|
+| 用户面向（web/admin/home/dashboard） | 1 | 2 | 3+ | 滚动更新和节点维护期间不能中断 |
+| 内部 API（lance、gateway 等） | 1 | 1–2 | 2 | 上游若有重试可单副本 |
+| 异步 worker（消费 BullMQ/MQ） | 1 | 1 | 1 | HPA 暂未支持，按需手动调高，见下方 |
+| 一次性任务/定时任务 | 1 | 1 | 1 | 不需多副本 |
+
+**何时必须多副本**
+
+- 用户能直接访问到（HTTP UI / 公网 API）—— pod 重启 / 节点 drain 时不能 503
+- 滚动发版期间不能中断（`maxUnavailable: 0` + replicas ≥ 2）
+- QPS 较高，单 pod 资源吃不下
+
+**何时可以单副本**
+
+- 内部低频服务（管理工具、cron 触发的 admin job）
+- 异步消费者：消息已持久化在 MQ，pod 重启期间消息不丢，重启后追上即可
+- test / dev / staging 等非关键环境
+
+**多副本前置条件**（缺一项就不要开多副本）
+
+1. **应用必须无状态** — 不依赖本地内存 / 本地文件系统的会话或缓存。如果有，先迁到 Redis / 数据库
+2. **健康检查正确** — `/health` 真实反映可服务能力（包括下游依赖检查），否则 readiness 让坏 pod 收流量
+3. **外部依赖能扛住 N 倍连接** — Postgres 连接池、Redis、上游 API 配额按 `replicas × per-pod-pool-size` 估算
+4. **没有"启动时单实例任务"** — 比如 DB migration、leader 选举抢锁等。这些应放到 init container 或 pre-deploy
+
+**示例：按 ring 配副本**
+
+```yaml
+defaultConfig:
+  replicas: 1                  # test 默认 1（成本优先）
+specificConfig:
+  - ring: staging
+    replicas: 2                # staging 验证 HA 行为
+  - ring: production
+    replicas: 3                # 生产至少 3，容忍 1 节点故障 + 1 滚动更新
+```
+
+**HPA / 自动扩缩容（暂未支持）**
+
+merlin 当前**只支持静态 `replicas`**，没有内置 HPA 字段。如需自动扩缩：
+
+- CPU/内存 触发的 HPA：手写 `KubernetesManifest` 资源塞 raw `HorizontalPodAutoscaler` YAML
+- 队列长度触发（推荐给 worker）：考虑部署 [KEDA](https://keda.sh/) 配 BullMQ trigger
+
+后续版本计划在 `KubernetesApp` 加 `autoscaling: { minReplicas, maxReplicas, targetCPU }` 字段。
 
 ---
 


### PR DESCRIPTION
## Summary

- `kubernetes-app-reference.md`: 新增「副本数推荐」小节，含 workload × ring 副本矩阵、多副本前置条件、`specificConfig` 示例
- `getting-started.md`: 新增「上线生产前 checklist」段落，覆盖副本/资源/安全/部署流程
- 文档中提到 HPA 暂未支持，跟进 issue #107

Closes #106

## Test plan

- [x] Markdown 渲染正常
- [x] 跨文档锚点链接有效