### PR TITLE
fix: lower default cpuRequest 250m → 100m, bump AKS maxCount → 6

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,7 +169,7 @@ defaultConfig:
 |------|--------|
 | `replicas` | `1` |
 | `healthPath` | `/`（用于 liveness/readiness/startup 探针） |
-| `resources.cpuRequest` / `cpuLimit` | `250m` / `500m` |
+| `resources.cpuRequest` / `cpuLimit` | `100m` / `500m` |
 | `resources.memoryRequest` / `memoryLimit` | `512Mi` / `1Gi` |
 | `ingress.path` | `/` |
 | `ingress.clusterIssuer` | `letsencrypt-prod` |

--- a/docs/kubernetes-app-reference.md
+++ b/docs/kubernetes-app-reference.md
@@ -21,7 +21,7 @@ defaultConfig:
 ```
 
 这就够了。Merlin 会自动填充：
-- CPU/内存限制（250m/512Mi request, 500m/1Gi limit）
+- CPU/内存限制（100m/512Mi request, 500m/1Gi limit）
 - 三个探针（liveness/readiness/startup，都用 HTTP GET `/`）
 - ClusterIP Service
 - 1 个副本
@@ -55,7 +55,7 @@ defaultConfig:
   # ── 可选：资源限制 ────────────────────────────────
   # 省略则用默认值
   resources:
-    cpuRequest: "250m"                # 默认：250m
+    cpuRequest: "100m"                # 默认：100m
     memoryRequest: 512Mi              # 默认：512Mi
     cpuLimit: "500m"                  # 默认：500m
     memoryLimit: 1Gi                  # 默认：1Gi
@@ -142,7 +142,7 @@ specificConfig:
 | `replicas` | `1` | |
 | `healthPath` | `/` | 用于所有探针 |
 | `imagePullPolicy` | `IfNotPresent` | |
-| `resources.cpuRequest` | `250m` | |
+| `resources.cpuRequest` | `100m` | 适合轻量服务；模型/重 SSR 类应显式覆盖 |
 | `resources.memoryRequest` | `512Mi` | |
 | `resources.cpuLimit` | `500m` | |
 | `resources.memoryLimit` | `1Gi` | |

--- a/shared-k8s-resource/sharedaks.yml
+++ b/shared-k8s-resource/sharedaks.yml
@@ -21,7 +21,7 @@ defaultConfig:
   nodeCount: 2
   enableAutoScaling: true
   minCount: 1
-  maxCount: 5
+  maxCount: 6
   networkPlugin: azure
   noWait: false
   tags:

--- a/src/compiler/kubernetesAppExpander.ts
+++ b/src/compiler/kubernetesAppExpander.ts
@@ -13,7 +13,7 @@ import type { ResourceYAML } from './schemas.js';
 
 const DEFAULT_REPLICAS = 1;
 const DEFAULT_HEALTH_PATH = '/';
-const DEFAULT_CPU_REQUEST = '250m';
+const DEFAULT_CPU_REQUEST = '100m';
 const DEFAULT_MEMORY_REQUEST = '512Mi';
 const DEFAULT_CPU_LIMIT = '500m';
 const DEFAULT_MEMORY_LIMIT = '1Gi';

--- a/src/compiler/test/kubernetesAppExpander.test.ts
+++ b/src/compiler/test/kubernetesAppExpander.test.ts
@@ -126,7 +126,7 @@ describe('kubernetesAppExpander', () => {
             const config = deployment.defaultConfig as Record<string, unknown>;
             const containers = config.containers as Record<string, unknown>[];
 
-            expect(containers[0].cpuRequest).toBe('250m');
+            expect(containers[0].cpuRequest).toBe('100m');
             expect(containers[0].memoryRequest).toBe('512Mi');
             expect(containers[0].cpuLimit).toBe('500m');
             expect(containers[0].memoryLimit).toBe('1Gi');


### PR DESCRIPTION
## Summary

- `src/compiler/kubernetesAppExpander.ts`: `DEFAULT_CPU_REQUEST` 250m → 100m
- `shared-k8s-resource/sharedaks.yml`: `maxCount` 5 → 6（autoscaler 兜底）
- 文档同步更新（`getting-started.md`, `kubernetes-app-reference.md`）
- 单测同步更新

## Why

测试集群 CPU requests 已分配 87-98%、实际使用仅 16-20% — 调度配额被 over-provision 严重浪费，导致 babbage / synapse rollout 反复因 `Insufficient cpu` 失败，autoscaler 顶到 maxCount=5。

实测多数业务 pod 使用 < 30m，250m 留 8× 余量过头。100m 留 3× 余量更合理；limit 仍是 500m，启动突发（Next.js 编译、模型加载）照样能爆。

## Migration

合并后各项目下次 `merlin deploy` 会自动应用新默认。**重量级应用需要显式覆盖**：
- alluneed（ASR 模型）：已在 alluneed 仓改为 200m
- trinity-admin（Next.js SSR）：评估是否保留 250m
- lovelace（模型推理）：评估

详见 #109 校准清单。

Closes #109

## Test plan

- [x] `pnpm test src/compiler/test/kubernetesAppExpander.test.ts` 全绿（53 tests）
- [ ] 合并后 `merlin compile` 各项目 yaml 通过
- [ ] 部署到 test ring 后 `kubectl describe nodes` CPU requests 利用率从 ~95% 降到 ~70%