### PR TITLE
fix(aks): bump shared AKS maxCount from 6 to 15

### DIFF
--- a/shared-k8s-resource/sharedaks.yml
+++ b/shared-k8s-resource/sharedaks.yml
@@ -21,7 +21,7 @@ defaultConfig:
   nodeCount: 2
   enableAutoScaling: true
   minCount: 1
-  maxCount: 6
+  maxCount: 15
   networkPlugin: azure
   noWait: false
   tags:


### PR DESCRIPTION
## Summary

- Raise shared AKS nodepool `maxCount` from 6 to 15 in `shared-k8s-resource/sharedaks.yml`
- Aligns merlin's declared state with the current Azure DSv3 family vCPU quota in koreacentral (30 vCPU = 15 × D2s_v3 nodes)
- Prevents `merlin deploy` from reconciling manually-scaled nodepools back down to 6 nodes
- No cost impact: `maxCount` is a ceiling — autoscaler only scales up when pending pods need it

## Test plan

- [ ] `merlin compile` succeeds
- [ ] `merlin deploy shared-k8s-resource --ring test --region koreacentral` dry-run shows the AKS nodepool update with `--max-count 15`
- [ ] After `--execute`, verify `az aks nodepool show ... --query maxCount` returns `15`
- [ ] Trigger a deployment that needs > 6 nodes, confirm autoscaler scales beyond 6 without `InsufficientVCPUQuota` errors

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)