### PR TITLE
feat(ci): replace alluneed federated credential from test to nightly env

### DIFF
--- a/shared-resource/sharedgithubsp.yml
+++ b/shared-resource/sharedgithubsp.yml
@@ -65,8 +65,8 @@ specificConfig:
     federatedCredentials:
       - name: trinity-github-nightly
         subject: repo:TheDeltaLab/trinity:environment:nightly
-      - name: alluneed-github-test
-        subject: repo:TheDeltaLab/alluneed:environment:test
+      - name: alluneed-github-nightly
+        subject: repo:TheDeltaLab/alluneed:environment:nightly
       - name: babbage-github-nightly
         subject: repo:TheDeltaLab/babbage:environment:nightly
       - name: synapse-github-nightly


### PR DESCRIPTION
## Summary

- Replace `alluneed-github-test` with `alluneed-github-nightly` in `sharedgithubsp.yml`
- Updates the subject from `environment:test` to `environment:nightly` to match the AKS deploy workflow

## Test plan
- [ ] Deploy `shared-resource` and confirm the new federated credential appears in Azure AD
- [ ] Trigger `aks-deploy.yml` in TheDeltaLab/alluneed and verify OIDC login succeeds

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)