### PR TITLE
fix(azure): handle Graph API eventual consistency in SP create

### DIFF
--- a/src/azure/azureServicePrincipal.ts
+++ b/src/azure/azureServicePrincipal.ts
@@ -250,29 +250,54 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
 
     // ── Full create flow ──────────────────────────────────────────────────────
 
+    /**
+     * Build a single bash command that captures the AD App's appId into `appIdVar`.
+     *
+     * Avoids the Microsoft Graph search-index eventual-consistency window:
+     *   - `az ad app list --filter "displayName eq ..."` reads from a search
+     *     index that lags writes by ~5–60 s. Calling it immediately after
+     *     `az ad app create` frequently returns `[]`, leaving the appId env var
+     *     empty and breaking the subsequent `az ad sp create --id ''`.
+     *
+     * Strategy: list-first (idempotent reuse if the app already exists) →
+     * fall back to `az ad app create --query appId -o tsv`, which reads the
+     * appId directly from the create response (strongly consistent — no index
+     * dependency).
+     */
+    private captureAppIdCommand(resource: AzureServicePrincipalResource, appIdVar: string): Command {
+        const displayName = this.getDisplayName(resource);
+        const redirectUris = resource.config.webRedirectUris ?? [];
+        const redirectFlag = redirectUris.length > 0
+            ? ` --web-redirect-uris ${redirectUris.map(u => `'${u}'`).join(' ')}`
+            : '';
+        const script = [
+            `APP_ID=$(az ad app list --filter "displayName eq '${displayName}'" --query "[0].appId" -o tsv 2>/dev/null || true)`,
+            `if [ -z "$APP_ID" ]; then`,
+            `  APP_ID=$(az ad app create --display-name '${displayName}'${redirectFlag} --query appId -o tsv)`,
+            `fi`,
+            `echo "$APP_ID"`,
+        ].join('\n');
+        return {
+            command: 'bash',
+            args: ['-c', script],
+            envCapture: appIdVar,
+        };
+    }
+
     renderCreate(resource: AzureServicePrincipalResource): Command[] {
         const commands: Command[] = [];
 
-        // 1. Create AD App Registration
-        const createArgs = ['ad', 'app', 'create', '--display-name', this.getDisplayName(resource)];
-        const redirectUris = resource.config.webRedirectUris ?? [];
-        if (redirectUris.length > 0) {
-            createArgs.push('--web-redirect-uris', ...redirectUris);
-        }
-        commands.push({ command: 'az', args: createArgs });
-
-        // 2. Capture the new appId
+        // 1+2. Create AD App Registration AND capture appId in a single step,
+        //      reading appId from `az ad app create`'s own stdout to avoid the
+        //      Graph search-index propagation delay. List-first for idempotency.
         const appIdVar = this.envVarName(resource, 'APP_ID');
-        commands.push({
-            command: 'az',
-            args: ['ad', 'app', 'list', '--filter', `displayName eq '${this.getDisplayName(resource)}'`, '--query', '[0].appId', '-o', 'tsv'],
-            envCapture: appIdVar,
-        });
+        commands.push(this.captureAppIdCommand(resource, appIdVar));
 
-        // 3. Create Service Principal from App
+        // 3. Create Service Principal from App (idempotent — show-or-create,
+        //    matching the pattern used by renderDirectoryRoles / renderAssignmentRequired).
         commands.push({
-            command: 'az',
-            args: ['ad', 'sp', 'create', '--id', `$${appIdVar}`],
+            command: 'bash',
+            args: ['-c', `az ad sp show --id $${appIdVar} 2>/dev/null || az ad sp create --id $${appIdVar}`],
         });
 
         // 4. API permissions (requiredResourceAccess)
@@ -302,15 +327,13 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
     // ── Update flow (federated credentials + role assignments only) ───────────
 
     renderUpdate(resource: AzureServicePrincipalResource, _appId: string, _objectId: string): Command[] {
-        // Capture appId at deploy time (SP already exists)
+        // Capture appId at deploy time using the same list-first / create-fallback
+        // helper as the create path — keeps the two paths in sync and protects
+        // against the App being deleted out-of-band between render and deploy.
         const appIdVar = this.envVarName(resource, 'APP_ID');
         const commands: Command[] = [];
 
-        commands.push({
-            command: 'az',
-            args: ['ad', 'app', 'list', '--filter', `displayName eq '${this.getDisplayName(resource)}'`, '--query', '[0].appId', '-o', 'tsv'],
-            envCapture: appIdVar,
-        });
+        commands.push(this.captureAppIdCommand(resource, appIdVar));
 
         // Ensure the Service Principal exists (App may exist without SP if a previous
         // create was interrupted, or if the App was created manually/via Portal)

--- a/src/azure/test/azureServicePrincipal.test.ts
+++ b/src/azure/test/azureServicePrincipal.test.ts
@@ -394,16 +394,22 @@ describe('AzureServicePrincipalRender', () => {
             mockNotFound();
             const resource = makeResource({ displayName: 'brainly-github-tst' });
             const cmds = await render.render(resource);
-            // First command should be az ad app create
-            expect(cmds[0].args).toContain('create');
+            // First command is the bash script that captures appId via list-first / create-fallback
+            expect(cmds[0].command).toBe('bash');
+            const script = cmds[0].args[1];
+            expect(script).toContain('az ad app create');
+            expect(script).toContain('--query appId');
+            expect(cmds[0].envCapture).toBeDefined();
         });
 
         it('calls renderUpdate when app already exists', async () => {
             mockAppExists();
             const resource = makeResource({ displayName: 'brainly-github-tst' });
             const cmds = await render.render(resource);
-            // First command should be az ad app list (capture appId)
-            expect(cmds[0].args).toContain('list');
+            // First command is the bash script that captures appId via list-first / create-fallback
+            expect(cmds[0].command).toBe('bash');
+            const script = cmds[0].args[1];
+            expect(script).toContain('az ad app list');
             expect(cmds[0].envCapture).toBeDefined();
         });
     });


### PR DESCRIPTION
## Summary

- `az ad app create` is strongly consistent, but the follow-up `az ad app list --filter "displayName eq ..."` reads from a search index that lags writes by 5–60 s — when run back-to-back in CI, the filter often returns `[]` and `az ad sp create --id ''` then fails. Re-running the workflow seconds later succeeds because the index has caught up.
- Replace the create + list-by-filter pair with a single `bash` script: list-first (idempotent reuse if the App already exists) → fall back to `az ad app create --query appId -o tsv`, which reads the appId straight from the create response, no index dependency.
- Make the subsequent `az ad sp create` idempotent (`az ad sp show ... || az ad sp create ...`), matching the pattern already used in `renderDirectoryRoles` / `renderAssignmentRequired`. Apply the same helper to `renderUpdate` so both paths stay in sync.

## Test plan

- [x] `pnpm test src/azure/test/azureServicePrincipal.test.ts` — 27/27 pass (2 expectations updated for the new bash-script first command)
- [x] `pnpm test` — full suite 921/921 pass
- [x] `pnpm build` — clean
- [ ] Next deploy of a fresh `AzureServicePrincipal` (e.g. a new project's `*-aad-test` app) succeeds on the first run with no manual re-run

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)