### PR TITLE
fix(azure): grant DelegatedPermissionGrant.ReadWrite.All to deploy SP + warn on admin-consent failure

### DIFF
--- a/scripts/setup-github-sp-permissions.sh
+++ b/scripts/setup-github-sp-permissions.sh
@@ -39,13 +39,24 @@ setup_sp() {
     echo "  App ID: $APP_ID"
 
     # ── 2. MS Graph API permissions ───────────────────────────────
-    echo "→ Setting MS Graph API permissions (Application.ReadWrite.All, AppRoleAssignment.ReadWrite.All, Directory.Read.All)..."
+    # Role IDs (Microsoft Graph application permissions):
+    #   1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9  Application.ReadWrite.All
+    #   06b708a9-e830-4db3-a914-8e69da51d44f  AppRoleAssignment.ReadWrite.All
+    #   7ab1d382-f21e-4acd-a863-ba3e13f7da61  Directory.Read.All
+    #   8e8e4742-1d95-4f68-9d56-6ee75648c72a  DelegatedPermissionGrant.ReadWrite.All
+    #     ↑ Required for `az ad app permission admin-consent` to succeed when
+    #       the requested scopes include OIDC delegated permissions
+    #       (User.Read, openid, profile, email). Without this, every new
+    #       AAD app that uses `apiPermissions: 'oidc'` requires manual
+    #       "Grant admin consent for tenant" in the Portal.
+    echo "→ Setting MS Graph API permissions (Application.ReadWrite.All, AppRoleAssignment.ReadWrite.All, Directory.Read.All, DelegatedPermissionGrant.ReadWrite.All)..."
     az ad app update --id "$APP_ID" --required-resource-accesses '[{
         "resourceAppId": "00000003-0000-0000-c000-000000000000",
         "resourceAccess": [
             {"id": "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9", "type": "Role"},
             {"id": "06b708a9-e830-4db3-a914-8e69da51d44f", "type": "Role"},
-            {"id": "7ab1d382-f21e-4acd-a863-ba3e13f7da61", "type": "Role"}
+            {"id": "7ab1d382-f21e-4acd-a863-ba3e13f7da61", "type": "Role"},
+            {"id": "8e8e4742-1d95-4f68-9d56-6ee75648c72a", "type": "Role"}
         ]
     }]'
 

--- a/src/azure/azureServicePrincipal.ts
+++ b/src/azure/azureServicePrincipal.ts
@@ -459,10 +459,30 @@ export class AzureServicePrincipalRender extends AzureResourceRender {
                 command: 'az',
                 args: ['ad', 'app', 'update', '--id', `$${appIdVar}`, '--required-resource-accesses', payload],
             },
-            // Auto-grant admin consent (mimics what Azure Portal does on manual creation)
+            // Auto-grant admin consent (mimics what Azure Portal does on manual creation).
+            // Failure modes worth distinguishing:
+            //   - "already granted"  → benign, deploy continues silently
+            //   - "Insufficient privileges" / "Authorization_RequestDenied"
+            //                        → real misconfiguration: the deploy SP / user lacks
+            //                          DelegatedPermissionGrant.ReadWrite.All on Microsoft Graph,
+            //                          so OIDC scopes will never auto-consent. Emit a loud
+            //                          warning to stderr so it doesn't get silently swallowed
+            //                          and surface as "users can't sign in" months later.
+            //   - other errors       → also warn but don't fail the deploy
             {
                 command: 'bash',
-                args: ['-c', `az ad app permission admin-consent --id $${appIdVar} || true`],
+                args: ['-c', [
+                    `OUT=$(az ad app permission admin-consent --id $${appIdVar} 2>&1)`,
+                    `RC=$?`,
+                    `if [ $RC -ne 0 ]; then`,
+                    `  if echo "$OUT" | grep -qiE 'Insufficient privileges|Authorization_RequestDenied|Forbidden'; then`,
+                    `    echo "⚠ admin-consent FAILED for $${appIdVar}: deploy identity lacks Microsoft Graph permission DelegatedPermissionGrant.ReadWrite.All (or AppRoleAssignment.ReadWrite.All). New users will see 'admin consent required' on first sign-in until granted manually in the Portal. Fix: run scripts/setup-github-sp-permissions.sh as a Global Admin." 1>&2`,
+                    `  else`,
+                    `    echo "⚠ admin-consent for $${appIdVar} returned non-zero (continuing): $OUT" 1>&2`,
+                    `  fi`,
+                    `fi`,
+                    `exit 0`,
+                ].join('\n')],
             },
         ];
     }


### PR DESCRIPTION
## Summary

- **Add `DelegatedPermissionGrant.ReadWrite.All`** (Microsoft Graph application role `8e8e4742-1d95-4f68-9d56-6ee75648c72a`) to the github CI SP in `scripts/setup-github-sp-permissions.sh`. This is the missing permission that was making `az ad app permission admin-consent` fail silently for every new AAD app — once the script is re-run as a Global Admin, future merlin deploys auto-consent and end users no longer see "Need admin approval" on first sign-in.
- **Stop swallowing admin-consent failures.** Replace `|| true` in `renderApiPermissions` with a script that classifies the failure: "Insufficient privileges / Authorization_RequestDenied / Forbidden" → loud `⚠ admin-consent FAILED` warning to stderr with a hint to re-run the bootstrap script; other errors → softer warning. Either way the deploy doesn't fail, but the failure no longer disappears for weeks.

## Test plan

- [x] `pnpm test src/azure/test/azureServicePrincipal.test.ts` — 27/27 pass (no test changes needed; the new bash script keeps the same Command shape)
- [x] `pnpm test` — full suite 921/921 pass
- [x] `pnpm build` — clean
- [x] `bash -n scripts/setup-github-sp-permissions.sh` — syntax OK
- [x] `bash -n` on the new admin-consent script literal — syntax OK
- [ ] Re-run `./scripts/setup-github-sp-permissions.sh` as a Global Admin against `brainly-github-tst` and `brainly-github-stg`
- [ ] Re-deploy `cortex-aad-test` / `lovelace-aad-test` and verify the admin-consent step succeeds (check `oauth2PermissionGrants` for `consentType: AllPrincipals`)
- [ ] Confirm Trevor (and any other dev not previously consented) can sign in to cortex / lovelace without 90094

## Background

For the diagnosis trail (Trevor's failed sign-ins, comparison of grants across trinity-admin / cortex / lovelace, why `Application Administrator` alone doesn't unblock this), see #126.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)