### PR TITLE
feat(aks): declare networkPolicy in YAML, support it on update

### DIFF
--- a/shared-k8s-resource/sharedaks.yml
+++ b/shared-k8s-resource/sharedaks.yml
@@ -23,6 +23,11 @@ defaultConfig:
   minCount: 1
   maxCount: 15
   networkPlugin: azure
+  # NetworkPolicy engine — without this, NetworkPolicy resources applied to
+  # the cluster are silently ignored (they get accepted by the API server
+  # but no controller enforces them at the data plane). `azure` integrates
+  # natively with Azure CNI; `cilium` would require recreating the cluster.
+  networkPolicy: azure
   noWait: false
   tags:
     merlin: "true"

--- a/src/kubernetes/kubernetesCluster.ts
+++ b/src/kubernetes/kubernetesCluster.ts
@@ -180,6 +180,11 @@ export class AzureAKSRender extends AzureResourceRender {
 
     private static readonly SIMPLE_PARAM_MAP_UPDATE: Record<string, string> = {
         'kubernetesVersion': '--kubernetes-version',
+        // `--network-policy` is supported on `az aks update` (azure | calico | cilium | none).
+        // Switching policy engines triggers a node-image rolling update on the cluster, so it
+        // applies in-place without recreating the cluster. networkPlugin is intentionally NOT
+        // here — changing the CNI plugin requires cluster recreation.
+        'networkPolicy': '--network-policy',
     };
 
     private static readonly BOOLEAN_FLAG_MAP: Record<string, string> = {

--- a/src/kubernetes/test/kubernetesCluster.test.ts
+++ b/src/kubernetes/test/kubernetesCluster.test.ts
@@ -319,6 +319,21 @@ describe('AzureAKSRender', () => {
             );
             expect(rotationCmd).toBeDefined();
         });
+
+        it('includes --network-policy on update when networkPolicy is set', async () => {
+            const resource = makeResource({ networkPolicy: 'azure' });
+            const commands = await render.render(resource);
+            const cmd = findAksUpdate(commands)!;
+            expect(cmd.args).toContain('--network-policy');
+            expect(cmd.args[cmd.args.indexOf('--network-policy') + 1]).toBe('azure');
+        });
+
+        it('does not include --network-policy on update when not set', async () => {
+            const resource = makeResource();
+            const commands = await render.render(resource);
+            const cmd = findAksUpdate(commands)!;
+            expect(cmd.args).not.toContain('--network-policy');
+        });
     });
 
     // ── 4. renderGetCredentials ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added `networkPolicy: azure` to `shared-k8s-resource/sharedaks.yml` — without this, all four shared AKS clusters were created with `--network-policy none` and any NetworkPolicy YAML applied to them was silently ignored at the data plane
- Added `networkPolicy` to the AKS render's `SIMPLE_PARAM_MAP_UPDATE` so it actually propagates on `az aks update` (was missing — silent no-op against existing clusters)

## Test plan

- [x] All 923 existing tests pass
- [x] Added 2 new test cases covering the update behavior
- [x] `merlin compile shared-k8s-resource` succeeds
- [x] Dry-run on the test cluster shows `az aks update ... --network-policy azure ...`
- [ ] After merge + redeploy, verify `az aks show ... --query networkProfile.networkPolicy` returns `azure` for all four clusters
- [ ] Apply a default-deny test NetworkPolicy and confirm it actually blocks traffic

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)