### PR TITLE
feat(kubernetes): add KubernetesNetworkPolicy DSL resource type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ Merlin supports multiple cloud providers via the `MERLIN_CLOUD` environment vari
 | `KUBERNETES_MANIFEST_TYPE` | `KubernetesManifest` |
 | `KUBERNETES_CONFIG_MAP_TYPE` | `KubernetesConfigMap` |
 | `KUBERNETES_SERVICE_ACCOUNT_TYPE` | `KubernetesServiceAccount` |
+| `KUBERNETES_NETWORK_POLICY_TYPE` | `KubernetesNetworkPolicy` |
 
 **Composite type** (compile-time only, expanded before code generation):
 
@@ -280,7 +281,7 @@ MERLIN_CLOUD=<other> → throws Error("Unknown cloud provider")
 
 Cloud-neutral (always registered):
   → GitHub: GitHubWorkflow
-  → Kubernetes: Namespace, Deployment, Service, Ingress, HelmRelease, Manifest, ConfigMap, ServiceAccount
+  → Kubernetes: Namespace, Deployment, Service, Ingress, HelmRelease, Manifest, ConfigMap, ServiceAccount, NetworkPolicy
 ```
 
 **Supported regions** (`src/common/resource.ts` — derived from `REGION_SHORT_NAME_MAP` as the single source of truth):
@@ -436,6 +437,53 @@ Override hooks (`deploymentOverrides`, `serviceOverrides`, `ingressOverrides`) a
 - **`wait`**: Whether to wait for the workflow run to complete before continuing
 
 Registered in `src/init.ts` outside the cloud-specific block (works with any cloud provider).
+
+### KubernetesNetworkPolicy Resource (`src/kubernetes/kubernetesNetworkPolicy.ts`)
+
+`KubernetesNetworkPolicy` is a cloud-neutral, high-level DSL that compiles down to one or more native `networking.k8s.io/v1` `NetworkPolicy` manifests. It exists to collapse the boilerplate of the **default-deny + selective-allow** pattern that every namespace needs once a NetworkPolicy engine is enabled.
+
+**Engine prerequisite:** the AKS cluster (or equivalent) must be created with `--network-policy <azure|calico|cilium>`. Without an engine, K8s accepts NetworkPolicy resources but the data plane silently ignores them. See `KubernetesClusterConfig.networkPolicy` and `shared-k8s-resource/sharedaks.yml`.
+
+**Top-level config fields:**
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `namespace` | string | required | Target namespace. |
+| `defaultDeny` | bool | `true` | Emit `<name>-default-deny` (deny all ingress + egress, ns-wide). |
+| `allowDns` | bool | `true` | Emit `<name>-allow-dns` (UDP/TCP 53 → kube-system). Without this, default-deny breaks every pod. |
+| `allowIntraNamespace` | bool | `true` | Emit `<name>-allow-intra-namespace` (pod-to-pod within ns, both directions). |
+| `allowExternalEgress` | bool | `false` | Emit `<name>-allow-external-egress` (`0.0.0.0/0` minus RFC1918). Lets pods reach public SaaS without enumerating endpoints. |
+| `ingress` | rule[] | `[]` | Per-rule allow list (each becomes one NetworkPolicy). |
+| `egress` | rule[] | `[]` | Per-rule allow list (each becomes one NetworkPolicy). |
+| `labels` | map | — | Extra labels added to every emitted policy. |
+
+**Rule shape (used in both `ingress[]` and `egress[]`):**
+
+```yaml
+ingress:
+  - name: from-trinity                  # → policy name `<resource.name>-from-trinity`
+    podSelector:                        # which pods this rule TARGETS (omit = all)
+      matchLabels: { app: alluneed }
+    from:                               # peer list (use `to:` for egress)
+      - sameNamespace: true             # shorthand for the current ns
+      - namespace: trinity              # cross-ns by `kubernetes.io/metadata.name`
+        podSelector:                    # narrow within that ns
+          matchExpressions:
+            - { key: app, operator: In, values: [trinity-web, trinity-worker] }
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except: [10.0.0.0/8]
+    ports:                              # omit = all ports
+      - { port: 8000 }                  # protocol defaults to TCP
+```
+
+**Peer DSL:** at most one of `sameNamespace` / `namespace` / `ipBlock` per peer. `podSelector` may be combined with namespace selectors to narrow within a namespace. The render emits `namespaceSelector` keyed on `kubernetes.io/metadata.name` (auto-injected by K8s 1.21+ on every namespace, so works without manually labeling target namespaces).
+
+**Output:** all manifests are written as a single multi-document YAML stream and applied with one `kubectl apply -f -` call (atomic per-resource rollout). `ensureNamespaceCommand()` is prepended so the namespace is created idempotently before the policies.
+
+Registered in `src/init.ts` cloud-neutral block. Short type name `k8snp`.
+
+**Scaffolding:** `merlin init` (web / api / worker templates) generates a `<project>networkpolicy.yml` with the default-deny + DNS + intra-ns + external-egress posture out of the box, plus a commented `app-from-nginx` ingress rule as a starting point. The `minimal` template intentionally skips it.
 
 ## Adding New Resource Types
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,9 +52,10 @@ merlin init myapp --template minimal
 | 2 | `{name}.yml` | ✅ | ✅ | ✅ | ✅ | ✅ | 主服务（KubernetesApp） |
 | 3 | `{name}workloadsa.yml` | — | ✅ | ✅ | ✅ | ✅ | ServiceAccount（Workload Identity） |
 | 4 | `{name}secretprovider.yml` | — | ✅ | ✅ | ✅ | ✅ | Key Vault → Pod 的 Secret 桥接 |
-| 5 | `{name}aad.yml` | — | — | — | — | ✅ | Azure AD App Registration |
-| 6 | `{name}oauth2proxy.yml` | — | — | — | — | ✅ | OAuth2 Proxy 服务 |
-| 7 | `{name}oauth2proxysecretprovider.yml` | — | — | — | — | ✅ | OAuth2 Proxy 的 Secret 桥接 |
+| 5 | `{name}networkpolicy.yml` | — | ✅ | ✅ | ✅ | ✅ | 网络策略（default-deny + 显式 allow-list） |
+| 6 | `{name}aad.yml` | — | — | — | — | ✅ | Azure AD App Registration |
+| 7 | `{name}oauth2proxy.yml` | — | — | — | — | ✅ | OAuth2 Proxy 服务 |
+| 8 | `{name}oauth2proxysecretprovider.yml` | — | — | — | — | ✅ | OAuth2 Proxy 的 Secret 桥接 |
 
 以下以 `merlin init myapp` (web 模板) 为例，逐个说明每个文件的作用和配置方法。
 
@@ -333,7 +334,90 @@ defaultConfig:
 
 ---
 
-### 文件 5：`{name}aad.yml` — Azure AD App Registration（仅 `--with-auth`）
+### 文件 5：`{name}networkpolicy.yml` — KubernetesNetworkPolicy（default-deny + allow-list）
+
+```yaml
+name: myapp-network-policy
+type: KubernetesNetworkPolicy
+
+dependencies:
+  - resource: KubernetesCluster.aks
+    isHardDependency: true
+
+defaultConfig:
+  namespace: myapp
+  defaultDeny: true
+  allowDns: true
+  allowIntraNamespace: true
+  allowExternalEgress: true
+
+  ingress:
+    - name: app-from-nginx
+      podSelector:
+        matchLabels:
+          app: myapp
+      from:
+        - namespace: ingress-nginx
+      ports:
+        - port: 3000  # TODO: match the port in myapp.yml
+```
+
+**这个文件的作用：** 给本命名空间设置**默认拒绝（default-deny）**网络姿态，只放行明确列出的来源/去向。编译后会展开为多个原生 `networking.k8s.io/v1` `NetworkPolicy`：
+
+- `<name>-default-deny` — 全命名空间禁所有 ingress + egress
+- `<name>-allow-dns` — 放行 `UDP/TCP 53 → kube-system`（否则 default-deny 会让所有 pod 解析 DNS 失败）
+- `<name>-allow-intra-namespace` — 同 namespace 内 pod 间互通
+- `<name>-allow-external-egress` — 放行 `0.0.0.0/0` 减去 RFC1918（让 pod 能访问 Azure Blob / Key Vault / AAD / OpenAI 等公网 SaaS）
+- 对 `ingress[]` / `egress[]` 中的每条规则各生成一个独立的 NetworkPolicy
+
+#### 引擎前置条件
+
+AKS 集群必须用 `networkPolicy: azure`（或 `calico` / `cilium`）创建。否则 K8s 接受这些资源但**数据面不会执行**，等于裸奔。共享 AKS 集群已经配好（见 `shared-k8s-resource/sharedaks.yml`）。
+
+#### 配置指南
+
+**生成的默认值（通常不用改）：**
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `defaultDeny` | `true` | 全 namespace 默认拒绝 |
+| `allowDns` | `true` | DNS 解析必须开，否则 pod 一启动就挂 |
+| `allowIntraNamespace` | `true` | 同 namespace pod 互通（worker ↔ api ↔ etc） |
+| `allowExternalEgress` | `true` | 公网出站，关掉前先确认没有 SaaS 调用 |
+
+**`ingress[]` / `egress[]` 是核心配置点。** 每条规则映射到一个独立的 NetworkPolicy。
+
+完整规则结构：
+
+```yaml
+ingress:
+  - name: from-trinity                  # → 编译为 <name>-from-trinity
+    podSelector:                        # 这条规则保护哪些 pod（省略=全部）
+      matchLabels: { app: myapp }
+    from:                               # 允许哪些来源（egress 规则写 to:）
+      - sameNamespace: true             # 当前 ns 简写
+      - namespace: trinity              # 跨 ns，按 kubernetes.io/metadata.name 匹配
+        podSelector:                    # 在那个 ns 里再缩小范围
+          matchExpressions:
+            - { key: app, operator: In, values: [trinity-web, trinity-worker] }
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except: [10.0.0.0/8]
+    ports:                              # 省略 = 所有端口
+      - { port: 8000 }                  # protocol 默认 TCP
+```
+
+**新增调用方时的运维约定：当有新的 namespace / 服务需要访问本 namespace，添加一条 `ingress[]` 规则，不要禁用整个策略。**
+
+详细字段语义见 [`merlin/CLAUDE.md` 的 KubernetesNetworkPolicy 章节](https://github.com/TheDeltaLab/merlin/blob/main/CLAUDE.md#kubernetesnetworkpolicy-resource-srckuberneteskubernetesnetworkpolicyts)。
+
+#### worker 模板的区别
+
+`worker` 模板生成时 `ingress` 块为注释占位（worker 通常没有外部入站）。如果 worker 需要被其他 namespace 调用，按上面的格式添加一条规则。
+
+---
+
+### 文件 6：`{name}aad.yml` — Azure AD App Registration（仅 `--with-auth`）
 
 ```yaml
 name: myapp-aad
@@ -417,7 +501,7 @@ exports:
 
 ---
 
-### 文件 6：`{name}oauth2proxy.yml` — OAuth2 Proxy 服务（仅 `--with-auth`）
+### 文件 7：`{name}oauth2proxy.yml` — OAuth2 Proxy 服务（仅 `--with-auth`）
 
 ```yaml
 name: myapp-oauth2-proxy
@@ -515,7 +599,7 @@ OAuth2 Proxy (/oauth2/auth)
 
 ---
 
-### 文件 7：`{name}oauth2proxysecretprovider.yml` — OAuth2 Proxy Secrets（仅 `--with-auth`）
+### 文件 8：`{name}oauth2proxysecretprovider.yml` — OAuth2 Proxy Secrets（仅 `--with-auth`）
 
 ```yaml
 name: myapp-oauth2-proxy-secret-provider
@@ -585,7 +669,7 @@ defaultConfig:
 
 ### 文件间的依赖关系
 
-以下是 `web --with-auth` 模板所有 7 个文件的完整依赖图（`→` 表示"依赖于"）：
+以下是 `web --with-auth` 模板所有 8 个文件的完整依赖图（`→` 表示"依赖于"）：
 
 ```
 merlin.yml (提供 project/ring/region 默认值，非资源)
@@ -604,6 +688,9 @@ merlin.yml (提供 project/ring/region 默认值，非资源)
     │     → KubernetesServiceAccount.myapp-workload-sa
     │     → AzureServicePrincipal.kv-workload ←(共享资源)
     │     → AzureKeyVault.shared ←(共享资源)
+    │
+    ├── myappnetworkpolicy.yml (KubernetesNetworkPolicy)
+    │     → KubernetesCluster.aks ←(共享资源)
     │
     ├── myappaad.yml (AzureServicePrincipal)
     │     → AzureKeyVault.shared ←(共享资源)
@@ -635,6 +722,8 @@ merlin.yml (提供 project/ring/region 默认值，非资源)
 | `worker`/`web`/`api` | Azure AD 租户 ID | `{name}secretprovider.yml` |
 | `worker`/`web`/`api` | Key Vault 中的 secret 名和映射 | `{name}secretprovider.yml` |
 | `worker`/`web`/`api` | 取消注释 secretProvider 和 envFrom（需要 secrets 时） | `{name}.yml` |
+| `worker`/`web`/`api` | NetworkPolicy 中 `app-from-nginx` 规则的 `port` 改成实际端口 | `{name}networkpolicy.yml` |
+| `worker`/`web`/`api` | 按需在 NetworkPolicy 中添加跨 namespace 调用方 | `{name}networkpolicy.yml` |
 | `--with-auth` | Azure AD 租户 ID ×3 处 | `{name}secretprovider.yml`、`{name}oauth2proxy.yml`、`{name}oauth2proxysecretprovider.yml` |
 | `--with-auth` | 域名 ×3 处（必须一致） | `{name}aad.yml`、`{name}oauth2proxy.yml`、`{name}.yml` |
 | `--with-auth` | Key Vault 名（每个 ring 各一个） | `{name}aad.yml` |
@@ -706,6 +795,7 @@ merlin deploy ./merlin-resources --ring test --region koreacentral --execute
 - [ ] **公网入口必须有认证** — 用户面向应用走 oauth2-proxy（`--with-auth` 模板自动配好）；webhook/回调端点用共享 secret
 - [ ] **Key Vault 联邦凭证已配** — 本项目 ServiceAccount 已加到 `shared-k8s-resource/sharedkvsp.yml`，且 merlin 已重新部署 shared SP（见 [排错指南](troubleshooting.md)）
 - [ ] **GitHub SP 联邦凭证已配** — 本项目 GitHub Actions workflow 已加到 `sharedgithubsp.yml`
+- [ ] **NetworkPolicy 的 allow-list 完整** — `{name}networkpolicy.yml` 中已列出所有合法调用方（其它 namespace 的 web/worker、ingress-nginx 等）。生产部署前用 `kubectl exec` 从一个**不该有权限**的 pod 里 `curl` 你的服务，确认被 default-deny 拦掉
 
 ### 部署流程
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -320,6 +320,86 @@ defaultConfig:
     };
 }
 
+function networkPolicyYml(project: string, opts: { ingress: boolean }): TemplateFile {
+    const ingressBlock = opts.ingress ? `
+  ingress:
+    # Allow ingress-nginx to reach the app on its service port.
+    - name: app-from-nginx
+      podSelector:
+        matchLabels:
+          app: ${project}
+      from:
+        - namespace: ingress-nginx
+      ports:
+        - port: 3000  # TODO: match the port in ${project}.yml
+
+    # Example: allow another namespace's pods to reach this app.
+    # - name: from-other-project
+    #   podSelector:
+    #     matchLabels:
+    #       app: ${project}
+    #   from:
+    #     - namespace: other-project
+    #       podSelector:
+    #         matchExpressions:
+    #           - key: app
+    #             operator: In
+    #             values: [other-web, other-worker]
+    #   ports:
+    #     - port: 3000
+` : `
+  # ingress: []  # No external ingress for worker-style services.
+  #              # Add rules here if other namespaces need to call this one.
+`;
+
+    return {
+        filename: `${project}networkpolicy.yml`,
+        description: 'KubernetesNetworkPolicy (default-deny + allow-list)',
+        content: `# Default-deny posture for the ${project} namespace.
+#
+# This compiles down to several native networking.k8s.io/v1 NetworkPolicy
+# manifests:
+#   - <name>-default-deny             (deny everything ns-wide)
+#   - <name>-allow-dns                (UDP/TCP 53 → kube-system)
+#   - <name>-allow-intra-namespace    (pods within ns can talk to each other)
+#   - <name>-allow-external-egress    (0.0.0.0/0 minus RFC1918 — public SaaS)
+#   - one policy per entry in ingress[] / egress[] below
+#
+# Engine prerequisite: the AKS cluster must be created with
+# \`networkPolicy: azure\` (or calico/cilium). Without an engine, K8s accepts
+# these resources but never enforces them at the data plane.
+#
+# When a new caller needs to reach this namespace, ADD a rule below — do NOT
+# disable the policy. See merlin/CLAUDE.md § "KubernetesNetworkPolicy Resource"
+# for the full DSL reference.
+
+name: ${project}-network-policy
+type: KubernetesNetworkPolicy
+
+dependencies:
+  - resource: KubernetesCluster.aks
+    isHardDependency: true
+
+defaultConfig:
+  namespace: ${project}
+  # All three default to true; listed explicitly here for documentation.
+  defaultDeny: true
+  allowDns: true
+  allowIntraNamespace: true
+  # Pods need to reach Azure Blob / Key Vault / AAD / OpenAI etc. on the
+  # public internet. Tighten to per-domain allowlists as a follow-up.
+  allowExternalEgress: true
+${ingressBlock}
+  # egress:
+  #   - name: to-otel
+  #     to:
+  #       - namespace: observability
+  #     ports:
+  #       - port: 4318
+`,
+    };
+}
+
 // ── Template set builders ────────────────────────────────────────────────────
 
 function buildTemplateFiles(project: string, options: InitOptions): TemplateFile[] {
@@ -335,6 +415,7 @@ function buildTemplateFiles(project: string, options: InitOptions): TemplateFile
                 appYml(project, { ingress: false, withAuth: false }),
                 workloadSaYml(project),
                 secretProviderYml(project),
+                networkPolicyYml(project, { ingress: false }),
             );
             break;
 
@@ -343,6 +424,7 @@ function buildTemplateFiles(project: string, options: InitOptions): TemplateFile
                 appYml(project, { ingress: true, withAuth: false }),
                 workloadSaYml(project),
                 secretProviderYml(project),
+                networkPolicyYml(project, { ingress: true }),
             );
             break;
 
@@ -356,12 +438,14 @@ function buildTemplateFiles(project: string, options: InitOptions): TemplateFile
                     aadYml(project),
                     oauth2ProxyYml(project),
                     oauth2ProxySecretProviderYml(project),
+                    networkPolicyYml(project, { ingress: true }),
                 );
             } else {
                 files.push(
                     appYml(project, { ingress: true, withAuth: false }),
                     workloadSaYml(project),
                     secretProviderYml(project),
+                    networkPolicyYml(project, { ingress: true }),
                 );
             }
             break;

--- a/src/common/cloudTypes.ts
+++ b/src/common/cloudTypes.ts
@@ -66,6 +66,7 @@ export const KUBERNETES_HELM_RELEASE_TYPE = 'KubernetesHelmRelease';
 export const KUBERNETES_MANIFEST_TYPE         = 'KubernetesManifest';
 export const KUBERNETES_CONFIG_MAP_TYPE      = 'KubernetesConfigMap';
 export const KUBERNETES_SERVICE_ACCOUNT_TYPE = 'KubernetesServiceAccount';
+export const KUBERNETES_NETWORK_POLICY_TYPE  = 'KubernetesNetworkPolicy';
 
 // ── Composite types (compile-time only, expanded before code generation) ──────
 export const KUBERNETES_APP_TYPE             = 'KubernetesApp';

--- a/src/common/statusChecker.ts
+++ b/src/common/statusChecker.ts
@@ -50,6 +50,7 @@ const CATEGORY_MAP: Record<string, ResourceCategory> = {
     'KubernetesConfigMap':            'kubernetes',
     'KubernetesManifest':             'kubernetes',
     'KubernetesServiceAccount':       'kubernetes',
+    'KubernetesNetworkPolicy':        'kubernetes',
 
     // Helm releases (queried via helm list)
     'KubernetesHelmRelease':          'helm',
@@ -147,6 +148,7 @@ const K8S_KIND_MAP: Record<string, string> = {
     'KubernetesIngress':        'ingress',
     'KubernetesConfigMap':      'configmap',
     'KubernetesServiceAccount': 'serviceaccount',
+    'KubernetesNetworkPolicy':  'networkpolicy',
 };
 
 // ── Status result types ──────────────────────────────────────────────────────

--- a/src/init.ts
+++ b/src/init.ts
@@ -26,6 +26,7 @@ import {
     KUBERNETES_MANIFEST_TYPE,
     KUBERNETES_CONFIG_MAP_TYPE,
     KUBERNETES_SERVICE_ACCOUNT_TYPE,
+    KUBERNETES_NETWORK_POLICY_TYPE,
 } from './common/cloudTypes.js';
 import { KubernetesNamespaceRender } from './kubernetes/kubernetesNamespace.js';
 import { KubernetesDeploymentRender } from './kubernetes/kubernetesDeployment.js';
@@ -35,6 +36,7 @@ import { KubernetesHelmReleaseRender } from './kubernetes/kubernetesHelmRelease.
 import { KubernetesManifestRender } from './kubernetes/kubernetesManifest.js';
 import { KubernetesConfigMapRender } from './kubernetes/kubernetesConfigMap.js';
 import { KubernetesServiceAccountRender } from './kubernetes/kubernetesServiceAccount.js';
+import { KubernetesNetworkPolicyRender } from './kubernetes/kubernetesNetworkPolicy.js';
 import {
     GITHUB_WORKFLOW_RESOURCE_TYPE,
     GitHubWorkflowRender,
@@ -70,6 +72,7 @@ registerRender(KUBERNETES_HELM_RELEASE_TYPE,    new KubernetesHelmReleaseRender(
 registerRender(KUBERNETES_MANIFEST_TYPE,        new KubernetesManifestRender());
 registerRender(KUBERNETES_CONFIG_MAP_TYPE,      new KubernetesConfigMapRender());
 registerRender(KUBERNETES_SERVICE_ACCOUNT_TYPE, new KubernetesServiceAccountRender());
+registerRender(KUBERNETES_NETWORK_POLICY_TYPE,  new KubernetesNetworkPolicyRender());
 
 export function initializeMerlin(): void {
     // Initialization happens during module load via the side-effects above.

--- a/src/kubernetes/index.ts
+++ b/src/kubernetes/index.ts
@@ -24,3 +24,14 @@ export type { KubernetesConfigMapConfig, KubernetesConfigMapResource } from './k
 
 export { KUBERNETES_SERVICE_ACCOUNT_TYPE, KubernetesServiceAccountRender } from './kubernetesServiceAccount.js';
 export type { KubernetesServiceAccountConfig, KubernetesServiceAccountResource } from './kubernetesServiceAccount.js';
+
+export { KUBERNETES_NETWORK_POLICY_TYPE, KubernetesNetworkPolicyRender } from './kubernetesNetworkPolicy.js';
+export type {
+    KubernetesNetworkPolicyConfig,
+    KubernetesNetworkPolicyResource,
+    NetworkPolicyRule,
+    NetworkPolicyPeer,
+    NetworkPolicyPort,
+    PodSelectorSpec,
+    PodLabelMatchExpression,
+} from './kubernetesNetworkPolicy.js';

--- a/src/kubernetes/kubernetesNetworkPolicy.ts
+++ b/src/kubernetes/kubernetesNetworkPolicy.ts
@@ -1,0 +1,351 @@
+import { Resource, ResourceSchema, Command, Render, RenderContext } from '../common/resource.js';
+import { resolveConfig } from '../common/paramResolver.js';
+import { manifestToYaml, ensureNamespaceCommand } from './kubernetesNamespace.js';
+import { MERLIN_YAML_FILE_PLACEHOLDER } from '../common/constants.js';
+
+export const KUBERNETES_NETWORK_POLICY_TYPE = 'KubernetesNetworkPolicy';
+
+// ── Public DSL types ─────────────────────────────────────────────────────────
+
+/**
+ * Match expression on a label key — mirrors K8s `matchExpressions[]` items.
+ * Use this when you need In/NotIn semantics; for simple equality use `matchLabels`.
+ */
+export interface PodLabelMatchExpression {
+    key: string;
+    operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist';
+    values?: string[];
+}
+
+export interface PodSelectorSpec {
+    /** Equality match (becomes K8s `matchLabels`). */
+    matchLabels?: Record<string, string>;
+    /** In/NotIn/Exists match (becomes K8s `matchExpressions`). */
+    matchExpressions?: PodLabelMatchExpression[];
+}
+
+/**
+ * One peer in an `ingress.from[]` or `egress.to[]` list. Exactly one of
+ *   - sameNamespace
+ *   - namespace
+ *   - ipBlock
+ * is typically set. `podSelector` may be combined with `namespace` /
+ * `sameNamespace` to narrow to specific pods within that namespace.
+ */
+export interface NetworkPolicyPeer {
+    /** Restrict to pods in the SAME namespace as this NetworkPolicy. */
+    sameNamespace?: boolean;
+    /**
+     * Restrict to pods in a specific other namespace, matched by
+     * `kubernetes.io/metadata.name` (auto-injected by K8s 1.21+ on every ns).
+     */
+    namespace?: string;
+    /** Optional pod selector applied within the chosen namespace. */
+    podSelector?: PodSelectorSpec;
+    /** CIDR-based peer (typically used for egress to public internet). */
+    ipBlock?: {
+        cidr: string;
+        except?: string[];
+    };
+}
+
+export interface NetworkPolicyPort {
+    /** Port number or named port. Required. */
+    port: number | string;
+    /** Defaults to TCP (matching K8s default). */
+    protocol?: 'TCP' | 'UDP' | 'SCTP';
+}
+
+export interface NetworkPolicyRule {
+    /**
+     * Logical name used to derive the K8s NetworkPolicy resource name.
+     * Final name: `<resource.name>-<rule.name>`.
+     */
+    name: string;
+    /**
+     * Pods this rule targets. If omitted, the rule applies to ALL pods in
+     * the namespace (i.e. `podSelector: {}`).
+     */
+    podSelector?: PodSelectorSpec;
+    /** Allowed source peers (for ingress) or destination peers (for egress). */
+    from?: NetworkPolicyPeer[];
+    to?: NetworkPolicyPeer[];
+    /**
+     * Optional port restriction. If omitted, ALL ports of the matched
+     * peers are allowed.
+     */
+    ports?: NetworkPolicyPort[];
+}
+
+export interface KubernetesNetworkPolicyConfig extends ResourceSchema {
+    /** Target namespace. Required. */
+    namespace: string;
+
+    /**
+     * If true (default), emit a "<name>-default-deny" NetworkPolicy that
+     * denies ALL ingress and egress in the namespace. Allow rules below
+     * then selectively re-open paths.
+     */
+    defaultDeny?: boolean;
+
+    /**
+     * If true (default), emit an egress allow-rule for kube-system DNS
+     * (UDP/TCP port 53). Without this, default-deny breaks every pod.
+     */
+    allowDns?: boolean;
+
+    /**
+     * If true (default true), emit an egress + ingress allow-rule for
+     * pod-to-pod traffic within the same namespace. Most apps depend on
+     * this (e.g. oauth2-proxy → main app).
+     */
+    allowIntraNamespace?: boolean;
+
+    /**
+     * If true, emit an egress allow-rule for `0.0.0.0/0` minus the three
+     * RFC1918 ranges. Lets pods talk to public SaaS endpoints (Azure
+     * Blob/KV/AAD, OpenAI, OTLP collectors with public IPs, etc.) without
+     * accidentally allowing traffic to other in-cluster namespaces.
+     * Defaults to false; set true if you don't want to enumerate every
+     * external destination.
+     */
+    allowExternalEgress?: boolean;
+
+    /** Per-rule ingress allow list. */
+    ingress?: NetworkPolicyRule[];
+
+    /** Per-rule egress allow list. */
+    egress?: NetworkPolicyRule[];
+
+    /** Optional extra labels added to every emitted NetworkPolicy. */
+    labels?: Record<string, string>;
+}
+
+export interface KubernetesNetworkPolicyResource extends Resource<KubernetesNetworkPolicyConfig> {}
+
+// ── Render ──────────────────────────────────────────────────────────────────
+
+/**
+ * Cloud-agnostic KubernetesNetworkPolicy render.
+ *
+ * Compiles a high-level allow-list DSL into one or more native K8s
+ * `networking.k8s.io/v1` NetworkPolicy manifests, then applies them with
+ * `kubectl apply`. The DSL collapses the boilerplate of the
+ * default-deny + selective-allow pattern that every production namespace
+ * needs once a NetworkPolicy engine (azure-npm / calico / cilium) is on.
+ *
+ * IMPORTANT: NetworkPolicy is enforced only when the AKS cluster (or
+ * equivalent) was created with `--network-policy <azure|calico|cilium>`.
+ * Without an engine, K8s accepts these manifests but silently ignores
+ * them at the data plane. See `KubernetesClusterConfig.networkPolicy`.
+ */
+export class KubernetesNetworkPolicyRender implements Render {
+    isGlobalResource = false;
+
+    getShortResourceTypeName(): string {
+        return 'k8snp';
+    }
+
+    async render(resource: Resource, context?: RenderContext): Promise<Command[]> {
+        const { resource: resolved, captureCommands } = await resolveConfig(resource);
+        const renderCommands = await this.renderImpl(resolved, context);
+        const ns = (resolved.config as Record<string, unknown>)?.namespace as string | undefined;
+        const nsCmd = ns ? [ensureNamespaceCommand(ns)] : [];
+        return [...captureCommands, ...nsCmd, ...renderCommands];
+    }
+
+    async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {
+        if (!KubernetesNetworkPolicyRender.isKubernetesNetworkPolicyResource(resource)) {
+            throw new Error(`Resource ${resource.name} is not a KubernetesNetworkPolicy resource`);
+        }
+
+        const config = resource.config as KubernetesNetworkPolicyConfig;
+        if (!config.namespace) {
+            throw new Error(`KubernetesNetworkPolicy ${resource.name}: 'namespace' is required`);
+        }
+
+        const baseName = resource.name;
+        const ns = config.namespace;
+        const baseLabels = config.labels;
+
+        // Apply defaults — `defaultDeny`, `allowDns`, `allowIntraNamespace` all
+        // default to true because the only sensible reason to use this type is
+        // to flip the namespace from open-by-default to deny-by-default.
+        const defaultDeny = config.defaultDeny ?? true;
+        const allowDns = config.allowDns ?? true;
+        const allowIntraNs = config.allowIntraNamespace ?? true;
+        const allowExtEgress = config.allowExternalEgress ?? false;
+
+        const manifests: Record<string, unknown>[] = [];
+
+        if (defaultDeny) {
+            manifests.push(buildPolicy({
+                name: `${baseName}-default-deny`,
+                namespace: ns,
+                labels: baseLabels,
+                podSelector: {},
+                policyTypes: ['Ingress', 'Egress'],
+            }));
+        }
+
+        if (allowDns) {
+            manifests.push(buildPolicy({
+                name: `${baseName}-allow-dns`,
+                namespace: ns,
+                labels: baseLabels,
+                podSelector: {},
+                policyTypes: ['Egress'],
+                egress: [{
+                    to: [{ namespaceSelector: nsLabelSelector('kube-system') }],
+                    ports: [
+                        { protocol: 'UDP', port: 53 },
+                        { protocol: 'TCP', port: 53 },
+                    ],
+                }],
+            }));
+        }
+
+        if (allowIntraNs) {
+            manifests.push(buildPolicy({
+                name: `${baseName}-allow-intra-namespace`,
+                namespace: ns,
+                labels: baseLabels,
+                podSelector: {},
+                policyTypes: ['Ingress', 'Egress'],
+                ingress: [{ from: [{ podSelector: {} }] }],
+                egress: [{ to: [{ podSelector: {} }] }],
+            }));
+        }
+
+        if (allowExtEgress) {
+            manifests.push(buildPolicy({
+                name: `${baseName}-allow-external-egress`,
+                namespace: ns,
+                labels: baseLabels,
+                podSelector: {},
+                policyTypes: ['Egress'],
+                egress: [{
+                    to: [{
+                        ipBlock: {
+                            cidr: '0.0.0.0/0',
+                            except: ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'],
+                        },
+                    }],
+                }],
+            }));
+        }
+
+        for (const rule of config.ingress ?? []) {
+            manifests.push(buildPolicy({
+                name: `${baseName}-${rule.name}`,
+                namespace: ns,
+                labels: baseLabels,
+                podSelector: rule.podSelector ?? {},
+                policyTypes: ['Ingress'],
+                ingress: [{
+                    from: (rule.from ?? []).map(p => peerToK8s(p, ns)),
+                    ports: rule.ports?.map(portToK8s),
+                }],
+            }));
+        }
+
+        for (const rule of config.egress ?? []) {
+            manifests.push(buildPolicy({
+                name: `${baseName}-${rule.name}`,
+                namespace: ns,
+                labels: baseLabels,
+                podSelector: rule.podSelector ?? {},
+                policyTypes: ['Egress'],
+                egress: [{
+                    to: (rule.to ?? []).map(p => peerToK8s(p, ns)),
+                    ports: rule.ports?.map(portToK8s),
+                }],
+            }));
+        }
+
+        // Stitch all manifests into a single multi-document YAML stream so
+        // `kubectl apply -f` handles them atomically (matching the alluneed
+        // pilot's behavior).
+        const fileContent = manifests.map(m => manifestToYaml(m)).join('\n---\n');
+
+        return [{
+            command: 'kubectl',
+            args: ['apply', '-f', MERLIN_YAML_FILE_PLACEHOLDER],
+            fileContent,
+        }];
+    }
+
+    private static isKubernetesNetworkPolicyResource(resource: Resource): resource is KubernetesNetworkPolicyResource {
+        return resource.type === KUBERNETES_NETWORK_POLICY_TYPE;
+    }
+}
+
+// ── Helpers (internal) ──────────────────────────────────────────────────────
+
+interface RawPolicySpec {
+    name: string;
+    namespace: string;
+    labels?: Record<string, string>;
+    podSelector: Record<string, unknown>;
+    policyTypes: ('Ingress' | 'Egress')[];
+    ingress?: Record<string, unknown>[];
+    egress?: Record<string, unknown>[];
+}
+
+function buildPolicy(spec: RawPolicySpec): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+        apiVersion: 'networking.k8s.io/v1',
+        kind: 'NetworkPolicy',
+        metadata: {
+            name: spec.name,
+            namespace: spec.namespace,
+            ...(spec.labels ? { labels: spec.labels } : {}),
+        },
+        spec: {
+            podSelector: spec.podSelector,
+            policyTypes: spec.policyTypes,
+            ...(spec.ingress ? { ingress: spec.ingress } : {}),
+            ...(spec.egress ? { egress: spec.egress } : {}),
+        },
+    };
+    return out;
+}
+
+function nsLabelSelector(ns: string): Record<string, unknown> {
+    return { matchLabels: { 'kubernetes.io/metadata.name': ns } };
+}
+
+function podSelectorToK8s(p: PodSelectorSpec | undefined): Record<string, unknown> {
+    if (!p) return {};
+    const out: Record<string, unknown> = {};
+    if (p.matchLabels) out.matchLabels = p.matchLabels;
+    if (p.matchExpressions) out.matchExpressions = p.matchExpressions;
+    return out;
+}
+
+function peerToK8s(p: NetworkPolicyPeer, currentNs: string): Record<string, unknown> {
+    // ipBlock is mutually exclusive with namespace/pod selectors.
+    if (p.ipBlock) {
+        return { ipBlock: p.ipBlock };
+    }
+
+    const out: Record<string, unknown> = {};
+
+    // `sameNamespace` implies the current namespace; if user also passed
+    // `namespace`, prefer the explicit one.
+    const targetNs = p.namespace ?? (p.sameNamespace ? currentNs : undefined);
+    if (targetNs !== undefined) {
+        out.namespaceSelector = nsLabelSelector(targetNs);
+    }
+    if (p.podSelector) {
+        out.podSelector = podSelectorToK8s(p.podSelector);
+    }
+    return out;
+}
+
+function portToK8s(p: NetworkPolicyPort): Record<string, unknown> {
+    return {
+        protocol: p.protocol ?? 'TCP',
+        port: p.port,
+    };
+}

--- a/src/kubernetes/test/kubernetesNetworkPolicy.test.ts
+++ b/src/kubernetes/test/kubernetesNetworkPolicy.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import {
+    KubernetesNetworkPolicyRender,
+    KUBERNETES_NETWORK_POLICY_TYPE,
+    KubernetesNetworkPolicyConfig,
+} from '../kubernetesNetworkPolicy.js';
+import { Resource } from '../../common/resource.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const render = new KubernetesNetworkPolicyRender();
+
+function makeResource(config: Partial<KubernetesNetworkPolicyConfig> = {}): Resource {
+    return {
+        name: 'alluneed-netpol',
+        type: KUBERNETES_NETWORK_POLICY_TYPE,
+        ring: 'test',
+        region: 'koreacentral',
+        dependencies: [],
+        exports: {},
+        config: {
+            namespace: 'alluneed',
+            ...config,
+        } as KubernetesNetworkPolicyConfig,
+    };
+}
+
+/**
+ * Returns the multi-document YAML body emitted by the render.
+ * The first command is `bash` (ensure-namespace), the second is `kubectl apply`.
+ */
+async function renderYaml(config: Partial<KubernetesNetworkPolicyConfig> = {}): Promise<string> {
+    const cmds = await render.render(makeResource(config));
+    const apply = cmds.find(c => c.command === 'kubectl');
+    expect(apply).toBeDefined();
+    return apply!.fileContent ?? '';
+}
+
+function countDocuments(yaml: string): number {
+    // Each NetworkPolicy doc is separated by `\n---\n`. A single doc has 0
+    // separators, two docs have 1, etc.
+    return (yaml.match(/\n---\n/g)?.length ?? 0) + 1;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('KubernetesNetworkPolicyRender', () => {
+    it('getShortResourceTypeName returns k8snp', () => {
+        expect(render.getShortResourceTypeName()).toBe('k8snp');
+    });
+
+    it('emits namespace ensure + kubectl apply commands', async () => {
+        const cmds = await render.render(makeResource());
+        expect(cmds[0].command).toBe('bash');
+        expect(cmds[0].args.join(' ')).toContain('create namespace alluneed');
+        const apply = cmds.find(c => c.command === 'kubectl')!;
+        expect(apply.args).toContain('apply');
+    });
+
+    it('throws when namespace is missing', async () => {
+        const resource = makeResource();
+        // strip the namespace
+        delete (resource.config as Record<string, unknown>).namespace;
+        await expect(render.render(resource)).rejects.toThrow(/namespace.*required/i);
+    });
+
+    // ── Defaults ────────────────────────────────────────────────────────────
+
+    it('emits default-deny + DNS + intra-ns by default (3 manifests)', async () => {
+        const yaml = await renderYaml();
+        expect(countDocuments(yaml)).toBe(3);
+        expect(yaml).toContain('alluneed-netpol-default-deny');
+        expect(yaml).toContain('alluneed-netpol-allow-dns');
+        expect(yaml).toContain('alluneed-netpol-allow-intra-namespace');
+    });
+
+    it('default-deny manifest has empty podSelector and both policy types', async () => {
+        const yaml = await renderYaml();
+        // The default-deny doc must contain a podSelector that allows nothing
+        // (i.e. the empty selector that matches all pods, combined with no
+        // ingress/egress rules and both Ingress + Egress in policyTypes).
+        expect(yaml).toMatch(/name: alluneed-netpol-default-deny[\s\S]*?podSelector: \{\}[\s\S]*?policyTypes:[\s\S]*?- Ingress[\s\S]*?- Egress/);
+    });
+
+    it('allow-dns manifest opens UDP/TCP 53 to kube-system', async () => {
+        const yaml = await renderYaml();
+        const dnsBlock = yaml.match(/name: alluneed-netpol-allow-dns[\s\S]*?(?=\n---|\n*$)/)?.[0] ?? '';
+        expect(dnsBlock).toContain('kubernetes.io/metadata.name: kube-system');
+        expect(dnsBlock).toContain('protocol: UDP');
+        expect(dnsBlock).toContain('protocol: TCP');
+        expect(dnsBlock).toContain('port: 53');
+    });
+
+    it('omits default-deny when defaultDeny=false', async () => {
+        const yaml = await renderYaml({ defaultDeny: false });
+        expect(yaml).not.toContain('default-deny');
+    });
+
+    it('omits intra-ns when allowIntraNamespace=false', async () => {
+        const yaml = await renderYaml({ allowIntraNamespace: false });
+        expect(yaml).not.toContain('allow-intra-namespace');
+    });
+
+    it('omits DNS when allowDns=false', async () => {
+        const yaml = await renderYaml({ allowDns: false });
+        expect(yaml).not.toContain('allow-dns');
+    });
+
+    it('emits external-egress only when allowExternalEgress=true', async () => {
+        const noExt = await renderYaml();
+        expect(noExt).not.toContain('allow-external-egress');
+
+        const withExt = await renderYaml({ allowExternalEgress: true });
+        expect(withExt).toContain('alluneed-netpol-allow-external-egress');
+        expect(withExt).toContain('cidr: 0.0.0.0/0');
+        expect(withExt).toContain('10.0.0.0/8');
+        expect(withExt).toContain('172.16.0.0/12');
+        expect(withExt).toContain('192.168.0.0/16');
+    });
+
+    // ── Custom rules ────────────────────────────────────────────────────────
+
+    it('compiles a cross-namespace ingress rule with pod label In selector', async () => {
+        const yaml = await renderYaml({
+            ingress: [{
+                name: 'from-trinity',
+                podSelector: { matchLabels: { app: 'alluneed' } },
+                from: [{
+                    namespace: 'trinity',
+                    podSelector: {
+                        matchExpressions: [{
+                            key: 'app',
+                            operator: 'In',
+                            values: ['trinity-web', 'trinity-worker'],
+                        }],
+                    },
+                }],
+                ports: [{ port: 8000 }],
+            }],
+        });
+
+        expect(yaml).toContain('alluneed-netpol-from-trinity');
+        expect(yaml).toContain('matchLabels:');
+        expect(yaml).toContain('app: alluneed');
+        expect(yaml).toContain('kubernetes.io/metadata.name: trinity');
+        expect(yaml).toContain('matchExpressions:');
+        expect(yaml).toContain('operator: In');
+        expect(yaml).toContain('- trinity-web');
+        expect(yaml).toContain('- trinity-worker');
+        expect(yaml).toContain('port: 8000');
+        expect(yaml).toContain('protocol: TCP');
+    });
+
+    it('compiles `sameNamespace: true` to a namespaceSelector for the current ns', async () => {
+        const yaml = await renderYaml({
+            ingress: [{
+                name: 'from-self',
+                from: [{ sameNamespace: true }],
+                ports: [{ port: 8000 }],
+            }],
+        });
+        expect(yaml).toContain('kubernetes.io/metadata.name: alluneed');
+    });
+
+    it('compiles an egress rule to observability:4318', async () => {
+        const yaml = await renderYaml({
+            egress: [{
+                name: 'to-otel',
+                to: [{ namespace: 'observability' }],
+                ports: [{ port: 4318 }],
+            }],
+        });
+        const block = yaml.match(/name: alluneed-netpol-to-otel[\s\S]*?(?=\n---|\n*$)/)?.[0] ?? '';
+        expect(block).toContain('kubernetes.io/metadata.name: observability');
+        expect(block).toContain('port: 4318');
+        expect(block).toMatch(/policyTypes:[\s\S]*?- Egress/);
+    });
+
+    it('compiles an egress ipBlock peer with except', async () => {
+        const yaml = await renderYaml({
+            egress: [{
+                name: 'public-internet',
+                to: [{ ipBlock: { cidr: '0.0.0.0/0', except: ['10.0.0.0/8'] } }],
+            }],
+        });
+        const block = yaml.match(/name: alluneed-netpol-public-internet[\s\S]*?(?=\n---|\n*$)/)?.[0] ?? '';
+        expect(block).toContain('cidr: 0.0.0.0/0');
+        expect(block).toContain('except:');
+        expect(block).toContain('10.0.0.0/8');
+    });
+
+    it('uses TCP as default protocol when not specified', async () => {
+        const yaml = await renderYaml({
+            ingress: [{
+                name: 'tcp-default',
+                from: [{ sameNamespace: true }],
+                ports: [{ port: 80 }],
+            }],
+        });
+        const block = yaml.match(/name: alluneed-netpol-tcp-default[\s\S]*?(?=\n---|\n*$)/)?.[0] ?? '';
+        expect(block).toContain('protocol: TCP');
+    });
+
+    // ── Bare config / manifest validity ──────────────────────────────────────
+
+    it('every emitted manifest declares networking.k8s.io/v1 + NetworkPolicy', async () => {
+        const yaml = await renderYaml({ allowExternalEgress: true });
+        const docs = yaml.split(/\n---\n/);
+        expect(docs.length).toBeGreaterThan(0);
+        for (const doc of docs) {
+            expect(doc).toContain('apiVersion: networking.k8s.io/v1');
+            expect(doc).toContain('kind: NetworkPolicy');
+            expect(doc).toContain('namespace: alluneed');
+        }
+    });
+
+    it('attaches custom labels to every emitted policy', async () => {
+        const yaml = await renderYaml({ labels: { 'managed-by': 'merlin' } });
+        const docs = yaml.split(/\n---\n/);
+        for (const doc of docs) {
+            expect(doc).toContain('managed-by: merlin');
+        }
+    });
+
+    it('produces a single doc when only default-deny is enabled', async () => {
+        const yaml = await renderYaml({ allowDns: false, allowIntraNamespace: false });
+        expect(countDocuments(yaml)).toBe(1);
+        expect(yaml).toContain('alluneed-netpol-default-deny');
+    });
+});

--- a/src/merlin.ts
+++ b/src/merlin.ts
@@ -586,11 +586,11 @@ program
     .option('--dir <path>', 'Output directory', './merlin-resources')
     .addHelpText('after', `
 Templates:
-  web (default)   Web service with Ingress + ServiceAccount + SecretProviderClass (4 files)
-  web --with-auth Web service + OAuth2 proxy + Azure AD App Registration (7 files)
-  api             API service with Ingress, no auth annotations (4 files)
-  worker          Background worker, no Ingress (4 files)
-  minimal         Just merlin.yml + KubernetesApp (2 files)
+  web (default)   Web service with Ingress + ServiceAccount + SecretProviderClass + NetworkPolicy (5 files)
+  web --with-auth Web service + OAuth2 proxy + Azure AD App Registration + NetworkPolicy (8 files)
+  api             API service with Ingress, no auth annotations + NetworkPolicy (5 files)
+  worker          Background worker, no Ingress + NetworkPolicy (5 files)
+  minimal         Just merlin.yml + KubernetesApp (2 files, no NetworkPolicy)
 
 Examples:
   $ merlin init myapp                        Web service template
@@ -600,10 +600,11 @@ Examples:
 
 Generated files (web template):
   merlin-resources/
-    merlin.yml              Project config (ring, region defaults)
-    <name>.yml              KubernetesApp (main service)
-    <name>workloadsa.yml    ServiceAccount (Workload Identity)
-    <name>secretprovider.yml SecretProviderClass (Key Vault CSI)
+    merlin.yml                Project config (ring, region defaults)
+    <name>.yml                KubernetesApp (main service)
+    <name>workloadsa.yml      ServiceAccount (Workload Identity)
+    <name>secretprovider.yml  SecretProviderClass (Key Vault CSI)
+    <name>networkpolicy.yml   KubernetesNetworkPolicy (default-deny + allow-list)
 `)
     .action(async (name, options) => {
         const projectName = name || path.basename(process.cwd());


### PR DESCRIPTION
## Summary

- Add high-level `KubernetesNetworkPolicy` resource type that compiles down to multiple native `networking.k8s.io/v1` `NetworkPolicy` manifests (default-deny, allow-dns, allow-intra-ns, allow-external-egress + per-rule allow-list)
- Wire into `merlin init` (web/api/worker templates) so new projects ship with default-deny posture
- Update `CLAUDE.md` and `docs/getting-started.md`
- 18 new unit tests; full suite 939 passing

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 939 / 939 passing
- [x] Live deployed to alluneed/staging-koreacentral and verified equivalence with the previous hand-written policies (trinity-admin blocked, trinity-web allowed, external egress allowed)
- [ ] Reviewer sanity-check the DSL field semantics in `src/kubernetes/kubernetesNetworkPolicy.ts`

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)