### PR TITLE
feat(azure): add AzureFederatedCredential resource for self-managed OIDC trusts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,6 +416,32 @@ Some Azure resources are tenant-scoped and have no region (e.g. `AzureADApp`). S
 
 **Why not `${ this.subscriptionId }`**: Merlin's `parseExpression` would try to evaluate it at compile time and fail since `subscriptionId` is not a valid resource property.
 
+### AzureFederatedCredential (`src/azure/azureFederatedCredential.ts`)
+
+`AzureFederatedCredential` lets each application **self-manage** its own OIDC trust relationships against a *shared* Service Principal (e.g. `brainly-github-tst`, `brainly-kv-workload-tst`), instead of enumerating every app's GitHub repo / K8s ServiceAccount inside the shared SP yaml.
+
+Why: the old design (federated credentials inlined into `shared-resource/sharedgithubsp.yml` and `shared-k8s-resource/sharedkvsp.yml`) reverse-coupled shared infra to every downstream app — onboarding a new app required editing merlin, releasing a new version, and bumping the dep everywhere. With this resource type, an app declares one yaml in its own repo and is done.
+
+**Tenant-scoped**: AD App / SP / federated credentials all live in Azure AD (Microsoft Graph), independent of the active ARM subscription. So `isGlobalResource: true`, and the same render works across rings/subscriptions. The SP's ARM `roleAssignments` (subscription-scoped RBAC like KV Secrets User, Storage Blob Data Contributor) stay in the shared SP yaml — they describe SP capabilities, not per-app trust.
+
+**Config:**
+
+| Field | Required | Notes |
+|---|---|---|
+| `servicePrincipal` | yes | Resource name (NOT Azure displayName) of the target `AzureServicePrincipal`. Looked up via `getResource(AzureServicePrincipal, <name>, <ring>)` so the same yaml hits the test SP in `ring=test` and the staging SP in `ring=staging`. Must be declared as a `dependencies[].resource: AzureServicePrincipal.<name>`. |
+| `subject` | yes | OIDC subject claim. GitHub: `repo:Org/Repo:environment:<ring>` or `repo:Org/Repo:ref:refs/heads/main`. K8s WI: `system:serviceaccount:<ns>:<sa>`. |
+| `issuer` | no | Defaults to GitHub Actions OIDC (`https://token.actions.githubusercontent.com`). For K8s WI, set to `${ KubernetesCluster.aks.oidcIssuerUrl }`. |
+| `credentialName` | no | Federated credential name on the SP (must be unique per SP). Defaults to `<project>-<name>`. |
+| `description` | no | Free-form. |
+
+**Idempotent**: emits `az ad app federated-credential update --federated-credential-id <name> --parameters '...' || az ad app federated-credential create --parameters '...'` — same pattern as `AzureServicePrincipalRender.renderFederatedCredentials()`.
+
+**Naming convention** for `credentialName`:
+- GitHub Actions: `<project>-github-<env>`, e.g. `trinity-github-nightly`, `trinity-github-staging`
+- K8s WI: `<project>-sa`, e.g. `trinity-sa`
+
+The shared SPs themselves (`github`, `kv-workload`) remain defined in merlin's `shared-resource/` and `shared-k8s-resource/` directories — only the per-app `federatedCredentials` arrays move out to the consuming apps.
+
 ### KubernetesApp Composite Type (`src/compiler/kubernetesAppExpander.ts`)
 
 `KubernetesApp` is a **compile-time composite type** that expands into 2–3 standard Kubernetes resources, reducing YAML boilerplate for typical web service deployments:

--- a/src/azure/azureFederatedCredential.ts
+++ b/src/azure/azureFederatedCredential.ts
@@ -1,0 +1,214 @@
+import { Resource, ResourceSchema, Command, RenderContext } from '../common/resource.js';
+import { AzureResourceRender } from './render.js';
+import { RING_SHORT_NAME_MAP } from '../common/resource.js';
+import { getResource } from '../common/registry.js';
+import { getRender } from '../common/resource.js';
+import {
+    AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE,
+    AzureServicePrincipalRender,
+    AzureServicePrincipalResource,
+} from './azureServicePrincipal.js';
+
+/**
+ * Resource type that lets each application self-manage its own federated
+ * credentials (OIDC trust relationships) on a *shared* Service Principal
+ * (e.g. `brainly-github-tst`, `brainly-kv-workload-tst`).
+ *
+ * Background:
+ *   The shared SPs (`shared-resource/sharedgithubsp.yml`,
+ *   `shared-k8s-resource/sharedkvsp.yml`) used to enumerate every
+ *   application's GitHub repo / K8s ServiceAccount in their
+ *   `federatedCredentials` arrays. That made the shared infra
+ *   reverse-coupled to each downstream app — onboarding a new app required
+ *   editing merlin, releasing a new version, and bumping the dep
+ *   everywhere. With this resource type, each app declares ONE yaml in its
+ *   own repo to register its OIDC subject against the shared SP.
+ *
+ * Tenant vs subscription:
+ *   AD App / SP / federated credentials are *tenant-scoped* (Microsoft
+ *   Graph), independent of the active ARM subscription. So this resource
+ *   is `isGlobalResource: true` and works across rings/subscriptions.
+ *
+ * Idempotency:
+ *   Mirrors the `update || create` pattern used in
+ *   AzureServicePrincipalRender.renderFederatedCredentials() so applying
+ *   the same yaml twice is a no-op.
+ */
+
+export const AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE = 'AzureFederatedCredential';
+
+/** GitHub Actions OIDC issuer — default for `issuer` when not specified. */
+export const GITHUB_ACTIONS_OIDC_ISSUER = 'https://token.actions.githubusercontent.com';
+
+export interface AzureFederatedCredentialConfig extends ResourceSchema {
+    /**
+     * The *resource name* (NOT the Azure displayName) of the target
+     * AzureServicePrincipal that this credential will be attached to.
+     *
+     * The render looks the SP up via `getResource(AzureServicePrincipal,
+     * <servicePrincipal>, <ring>)` so the same yaml can target different
+     * concrete SPs in test vs staging vs production.
+     *
+     * Example: `github`, `kv-workload`.
+     */
+    servicePrincipal: string;
+
+    /**
+     * OIDC subject claim. Examples:
+     *   - GitHub Actions:
+     *       repo:TheDeltaLab/trinity:environment:test
+     *       repo:TheDeltaLab/trinity:ref:refs/heads/main
+     *   - K8s Workload Identity:
+     *       system:serviceaccount:trinity:trinity-workload-sa
+     */
+    subject: string;
+
+    /**
+     * Token issuer URL. Defaults to GitHub Actions OIDC.
+     * For K8s Workload Identity, set this to the AKS OIDC issuer URL —
+     * typically `${ KubernetesCluster.aks.oidcIssuerUrl }`.
+     */
+    issuer?: string;
+
+    /**
+     * Name of the federated credential on the SP (must be unique per SP).
+     * Defaults to `[<project>-]<name>`.
+     */
+    credentialName?: string;
+
+    /** Free-form description (optional). */
+    description?: string;
+}
+
+export interface AzureFederatedCredentialResource extends Resource<AzureFederatedCredentialConfig> {}
+
+export class AzureFederatedCredentialRender extends AzureResourceRender {
+    supportConnectorInResourceName: boolean = true;
+
+    /**
+     * Federated credentials live on AD Apps which are tenant-scoped — there
+     * is no region.
+     */
+    override isGlobalResource: boolean = true;
+
+    override getShortResourceTypeName(): string {
+        return 'fedcred';
+    }
+
+    /**
+     * Compute the federated credential's name on the SP.
+     *
+     *   <credentialName>            (if explicitly set)
+     *   <project>-<resource.name>   (if project is set)
+     *   <resource.name>             (otherwise)
+     */
+    getCredentialName(resource: AzureFederatedCredentialResource): string {
+        if (resource.config.credentialName) return resource.config.credentialName;
+        return [resource.project, resource.name].filter(Boolean).join('-');
+    }
+
+    async renderImpl(resource: Resource, _context?: RenderContext): Promise<Command[]> {
+        if (!AzureFederatedCredentialRender.isAzureFederatedCredentialResource(resource)) {
+            throw new Error(
+                `Resource ${resource.name} is not an AzureFederatedCredential resource`
+            );
+        }
+
+        const fc = resource as AzureFederatedCredentialResource;
+
+        // 1. Resolve target SP via registry. Global resource fall-through in
+        //    getResource() means a regional caller can find a global SP by
+        //    ring alone.
+        const spName = fc.config.servicePrincipal;
+        if (!spName || typeof spName !== 'string') {
+            throw new Error(
+                `AzureFederatedCredential ${fc.name}: 'servicePrincipal' is required and must be a string`
+            );
+        }
+        const sp = getResource(AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE, spName, fc.ring) as
+            | AzureServicePrincipalResource
+            | undefined;
+        if (!sp) {
+            throw new Error(
+                `AzureFederatedCredential ${fc.name}: target AzureServicePrincipal '${spName}' ` +
+                    `not found in registry for ring '${fc.ring}'. ` +
+                    `Make sure it is declared as a dependency: ` +
+                    `'AzureServicePrincipal.${spName}'.`
+            );
+        }
+
+        // 2. Use the SP render's getDisplayName() to compute the Azure AD
+        //    App displayName (which may differ from the resource name).
+        const spRender = getRender(AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE) as
+            | AzureServicePrincipalRender
+            | undefined;
+        if (!spRender) {
+            throw new Error(
+                `AzureFederatedCredential ${fc.name}: AzureServicePrincipal render not registered`
+            );
+        }
+        const displayName = spRender.getDisplayName(sp);
+
+        // 3. Build the JSON parameters body — same shape as
+        //    AzureServicePrincipalRender.renderFederatedCredentials().
+        const credName = this.getCredentialName(fc);
+        const params = JSON.stringify({
+            name: credName,
+            issuer: fc.config.issuer ?? GITHUB_ACTIONS_OIDC_ISSUER,
+            subject: fc.config.subject,
+            description: fc.config.description ?? '',
+            audiences: ['api://AzureADTokenExchange'],
+        });
+
+        // 4. Capture the AD App's appId at deploy time (list-first; do NOT
+        //    create the App — that is the SP's responsibility), then
+        //    update-or-create the federated credential.
+        const appIdVar = this.envVarName(fc, 'APP_ID');
+        const captureScript = [
+            `APP_ID=$(az ad app list --filter "displayName eq '${displayName}'" --query "[0].appId" -o tsv 2>/dev/null || true)`,
+            `if [ -z "$APP_ID" ]; then`,
+            `  echo "AzureFederatedCredential ${fc.name}: AD App '${displayName}' not found. ` +
+                `Deploy the AzureServicePrincipal '${spName}' first." 1>&2`,
+            `  exit 1`,
+            `fi`,
+            `echo "$APP_ID"`,
+        ].join('\n');
+
+        return [
+            {
+                command: 'bash',
+                args: ['-c', captureScript],
+                envCapture: appIdVar,
+            },
+            {
+                command: 'bash',
+                args: [
+                    '-c',
+                    `az ad app federated-credential update --id $${appIdVar} ` +
+                        `--federated-credential-id ${credName} --parameters '${params}' || ` +
+                        `az ad app federated-credential create --id $${appIdVar} ` +
+                        `--parameters '${params}'`,
+                ],
+            },
+        ];
+    }
+
+    private static isAzureFederatedCredentialResource(
+        resource: Resource
+    ): resource is AzureFederatedCredentialResource {
+        return resource.type === AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE;
+    }
+
+    /**
+     * Build a unique shell environment variable name for this resource + suffix.
+     * Pattern: MERLIN_FEDCRED_<PROJECT>_<NAME>_<RING>_<SUFFIX>
+     */
+    private envVarName(resource: AzureFederatedCredentialResource, suffix: string): string {
+        const parts = ['MERLIN', 'FEDCRED'];
+        if (resource.project) parts.push(resource.project.toUpperCase().replace(/-/g, '_'));
+        parts.push(resource.name.toUpperCase().replace(/-/g, '_'));
+        parts.push((RING_SHORT_NAME_MAP[resource.ring] || resource.ring).toUpperCase());
+        parts.push(suffix);
+        return parts.join('_');
+    }
+}

--- a/src/azure/register.ts
+++ b/src/azure/register.ts
@@ -35,6 +35,7 @@ import { AZURE_DNS_ZONE_RESOURCE_TYPE, AzureDnsZoneRender } from './azureDnsZone
 import { AZURE_CONTAINER_APP_ENVIRONMENT_TYPE, AzureContainerAppEnvironmentRender } from './azureContainerAppEnvironment.js';
 import { AZURE_LOG_ANALYTICS_WORKSPACE_RESOURCE_TYPE, AzureLogAnalyticsWorkspaceRender } from './azureLogAnalyticsWorkspace.js';
 import { AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE, AzureServicePrincipalRender } from './azureServicePrincipal.js';
+import { AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE, AzureFederatedCredentialRender } from './azureFederatedCredential.js';
 import { AZURE_KEY_VAULT_RESOURCE_TYPE, AzureKeyVaultRender } from './azureKeyVault.js';
 import { AZURE_REDIS_ENTERPRISE_RESOURCE_TYPE, AzureRedisEnterpriseRender } from './azureRedisEnterprise.js';
 import { AZURE_POSTGRESQL_RESOURCE_TYPE, AzurePostgreSQLFlexibleRender } from './azurePostgreSQLFlexible.js';
@@ -94,6 +95,7 @@ export function registerAzureProviders(): void {
     registerRender(AZURE_LOG_ANALYTICS_WORKSPACE_RESOURCE_TYPE, new AzureLogAnalyticsWorkspaceRender());
     registerRender(AZURE_CONTAINER_APP_ENVIRONMENT_TYPE,        new AzureContainerAppEnvironmentRender());
     registerRender(AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE,       new AzureServicePrincipalRender());
+    registerRender(AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE,    new AzureFederatedCredentialRender());
     registerRender(AZURE_KEY_VAULT_RESOURCE_TYPE,               new AzureKeyVaultRender());
     registerRender(AZURE_REDIS_ENTERPRISE_RESOURCE_TYPE,        new AzureRedisEnterpriseRender());
     registerRender(AZURE_POSTGRESQL_RESOURCE_TYPE,              new AzurePostgreSQLFlexibleRender());

--- a/src/azure/test/azureFederatedCredential.test.ts
+++ b/src/azure/test/azureFederatedCredential.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    AzureFederatedCredentialRender,
+    AzureFederatedCredentialResource,
+    AzureFederatedCredentialConfig,
+    AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE,
+    GITHUB_ACTIONS_OIDC_ISSUER,
+} from '../azureFederatedCredential.js';
+import {
+    AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE,
+    AzureServicePrincipalRender,
+    AzureServicePrincipalResource,
+} from '../azureServicePrincipal.js';
+import { registerResource, clearRegistry } from '../../common/registry.js';
+import { registerRender } from '../../common/resource.js';
+
+// Mock execAsync (not exercised here but registry stamping uses getRender)
+vi.mock('../../common/constants.js', async (importOriginal) => {
+    const actual = (await importOriginal()) as any;
+    return { ...actual, execAsync: vi.fn() };
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(
+    config: Partial<AzureFederatedCredentialConfig> = {},
+    overrides: Partial<Omit<AzureFederatedCredentialResource, 'config'>> = {}
+): AzureFederatedCredentialResource {
+    return {
+        name: 'github',
+        type: AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE,
+        ring: 'test',
+        project: 'trinity',
+        authProvider: { provider: {} as any, args: {} },
+        dependencies: [],
+        exports: {},
+        config: {
+            servicePrincipal: 'github',
+            subject: 'repo:TheDeltaLab/trinity:environment:nightly',
+            ...config,
+        },
+        ...overrides,
+    } as AzureFederatedCredentialResource;
+}
+
+function registerStubSp(
+    name = 'github',
+    ring: 'test' | 'staging' = 'test',
+    displayName = 'brainly-github-tst'
+): AzureServicePrincipalResource {
+    const sp: AzureServicePrincipalResource = {
+        name,
+        type: AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE,
+        ring,
+        // No project → "shared" prefix in default getResourceName, but here we
+        // pin displayName to match the real shared SP naming.
+        authProvider: { provider: {} as any, args: {} },
+        dependencies: [],
+        exports: {},
+        config: { displayName },
+    } as AzureServicePrincipalResource;
+    registerResource(sp);
+    return sp;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AzureFederatedCredentialRender', () => {
+    let render: AzureFederatedCredentialRender;
+
+    beforeEach(() => {
+        clearRegistry();
+        // Ensure SP render is registered so getResource() can stamp
+        // isGlobalResource on registered SP entries.
+        registerRender(AZURE_SERVICE_PRINCIPAL_RESOURCE_TYPE, new AzureServicePrincipalRender());
+        registerRender(
+            AZURE_FEDERATED_CREDENTIAL_RESOURCE_TYPE,
+            new AzureFederatedCredentialRender()
+        );
+        render = new AzureFederatedCredentialRender();
+        vi.resetAllMocks();
+    });
+
+    describe('basic metadata', () => {
+        it('isGlobalResource is true (tenant-scoped)', () => {
+            expect(render.isGlobalResource).toBe(true);
+        });
+
+        it('getShortResourceTypeName returns fedcred', () => {
+            expect(render.getShortResourceTypeName()).toBe('fedcred');
+        });
+    });
+
+    describe('getCredentialName', () => {
+        it('uses explicit credentialName when set', () => {
+            const r = makeResource({ credentialName: 'custom-cred' });
+            expect(render.getCredentialName(r)).toBe('custom-cred');
+        });
+
+        it('defaults to <project>-<name>', () => {
+            const r = makeResource();
+            expect(render.getCredentialName(r)).toBe('trinity-github');
+        });
+
+        it('falls back to <name> if no project', () => {
+            const r = makeResource({}, { project: undefined });
+            expect(render.getCredentialName(r)).toBe('github');
+        });
+    });
+
+    describe('renderImpl - happy path', () => {
+        it('emits 2 commands: capture appId + update-or-create fedcred', async () => {
+            registerStubSp();
+            const r = makeResource();
+            const cmds = await render.render(r);
+
+            expect(cmds).toHaveLength(2);
+
+            const captureCmd = cmds[0];
+            expect(captureCmd.command).toBe('bash');
+            expect(captureCmd.envCapture).toBe(
+                'MERLIN_FEDCRED_TRINITY_GITHUB_TST_APP_ID'
+            );
+            expect(captureCmd.args[1]).toContain(
+                "az ad app list --filter \"displayName eq 'brainly-github-tst'\""
+            );
+
+            const fcCmd = cmds[1];
+            expect(fcCmd.command).toBe('bash');
+            expect(fcCmd.args[1]).toContain(
+                'az ad app federated-credential update'
+            );
+            expect(fcCmd.args[1]).toContain('|| az ad app federated-credential create');
+            expect(fcCmd.args[1]).toContain('trinity-github');
+            expect(fcCmd.args[1]).toContain(
+                'repo:TheDeltaLab/trinity:environment:nightly'
+            );
+        });
+
+        it('uses GitHub Actions OIDC issuer by default', async () => {
+            registerStubSp();
+            const r = makeResource();
+            const cmds = await render.render(r);
+            expect(cmds[1].args[1]).toContain(GITHUB_ACTIONS_OIDC_ISSUER);
+        });
+
+        it('uses custom issuer when provided (e.g. AKS OIDC for K8s WI)', async () => {
+            registerStubSp(
+                'kv-workload',
+                'test',
+                'brainly-kv-workload-tst'
+            );
+            const r = makeResource(
+                {
+                    servicePrincipal: 'kv-workload',
+                    issuer: 'https://oidc.aks.example.com/abc/',
+                    subject: 'system:serviceaccount:trinity:trinity-workload-sa',
+                    credentialName: 'trinity-sa',
+                },
+                { name: 'kv-workload' }
+            );
+            const cmds = await render.render(r);
+            expect(cmds[1].args[1]).toContain('https://oidc.aks.example.com/abc/');
+            expect(cmds[1].args[1]).toContain(
+                'system:serviceaccount:trinity:trinity-workload-sa'
+            );
+            expect(cmds[1].args[1]).toContain('trinity-sa');
+            // Should NOT also contain the GH OIDC issuer
+            expect(cmds[1].args[1]).not.toContain(GITHUB_ACTIONS_OIDC_ISSUER);
+        });
+
+        it('embeds audiences=["api://AzureADTokenExchange"]', async () => {
+            registerStubSp();
+            const r = makeResource();
+            const cmds = await render.render(r);
+            expect(cmds[1].args[1]).toContain('api://AzureADTokenExchange');
+        });
+    });
+
+    describe('renderImpl - error cases', () => {
+        it('throws a clear error when target SP is not in the registry', async () => {
+            const r = makeResource({ servicePrincipal: 'missing-sp' });
+            await expect(render.render(r)).rejects.toThrow(
+                /AzureServicePrincipal 'missing-sp' not found in registry/
+            );
+        });
+
+        it('throws when servicePrincipal is missing from config', async () => {
+            registerStubSp();
+            const r = makeResource({ servicePrincipal: undefined as any });
+            await expect(render.render(r)).rejects.toThrow(/'servicePrincipal' is required/);
+        });
+    });
+
+    describe('cross-ring lookup', () => {
+        it('finds the staging SP when resource ring is staging', async () => {
+            registerStubSp('github', 'test', 'brainly-github-tst');
+            registerStubSp('github', 'staging', 'brainly-github-stg');
+            const r = makeResource(
+                { subject: 'repo:TheDeltaLab/trinity:environment:staging' },
+                { ring: 'staging' }
+            );
+            const cmds = await render.render(r);
+            expect(cmds[0].args[1]).toContain('brainly-github-stg');
+            expect(cmds[0].args[1]).not.toContain('brainly-github-tst');
+            expect(cmds[0].envCapture).toBe(
+                'MERLIN_FEDCRED_TRINITY_GITHUB_STG_APP_ID'
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- New global render `AzureFederatedCredential` lets each app self-manage its OIDC trust against the shared SPs (`brainly-github-*`, `brainly-kv-workload-*`) from its own repo
- Looks up the target SP via `getResource(AzureServicePrincipal, name, ring)` so the same yaml hits the test SP in `ring=test` and the staging SP in `ring=staging`
- Tenant-scoped (Microsoft Graph), so works across rings even though rings are split across ARM subscriptions
- Idempotent (`update || create`), 12 unit tests, full suite (953) green

This is PR 1 of 3:
1. **(this PR)** merlin: add the resource type
2. each app (parallel): add `<app>githubfedcred.yml` + `<app>kvfedcred.yml` to its own merlin-resources, deploy
3. merlin cleanup: strip per-app `federatedCredentials:` from `sharedgithubsp.yml` / `sharedkvsp.yml`

## Test plan

- [x] `pnpm test src/azure/test/azureFederatedCredential.test.ts` — 12 passing
- [x] `pnpm test` — 953 passing, no regressions
- [x] `pnpm build` — clean
- [ ] After release: PR 2 in trinity / synapse / lovelace / babbage / cortex / alluneed proves end-to-end (GH OIDC token exchange + KV CSI secret mount still work)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)